### PR TITLE
[✅ chore/#20] 성공/에러 메시지 필드 및 enum 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/domain/enums/Grade.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Grade.java
@@ -5,10 +5,10 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum Grade {
-    FRESHMAN(1, "1학년"),
-    SOPHOMORE(2, "2학년"),
-    JUNIOR(3, "3학년"),
-    SENIOR(4, "4학년");
+    FRESHMAN(0, "1학년"),
+    SOPHOMORE(1, "2학년"),
+    JUNIOR(2, "3학년"),
+    SENIOR(3, "4학년");
 
     private final int key;
     private final String value;

--- a/src/main/java/org/terning/terningserver/domain/enums/WorkingPeriod.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/WorkingPeriod.java
@@ -5,9 +5,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum WorkingPeriod {
-    OPTION1(1, "1개월 ~ 3개월"),
-    OPTION2(2, "4개월 ~ 6개월"),
-    OPTION3(3, "7개월 이상");
+    OPTION1(0, "1개월 ~ 3개월"),
+    OPTION2(1, "4개월 ~ 6개월"),
+    OPTION3(2, "7개월 이상");
 
     private final int key;
     private final String value;

--- a/src/main/java/org/terning/terningserver/exception/dto/ErrorResponse.java
+++ b/src/main/java/org/terning/terningserver/exception/dto/ErrorResponse.java
@@ -11,9 +11,7 @@ import java.util.List;
 @Builder
 public record ErrorResponse(
         int status,
-        String message,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        List<ValidationError> errors
+        String message
 ) {
     public static ErrorResponse of(int status, String message){
         return ErrorResponse.builder()
@@ -26,7 +24,6 @@ public record ErrorResponse(
         return ErrorResponse.builder()
                 .status(status)
                 .message(message)
-                .errors(ValidationError.of(bindingResult))
                 .build();
     }
 

--- a/src/main/java/org/terning/terningserver/exception/dto/SuccessResponse.java
+++ b/src/main/java/org/terning/terningserver/exception/dto/SuccessResponse.java
@@ -4,19 +4,18 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.terning.terningserver.exception.enums.SuccessMessage;
 
-@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@JsonPropertyOrder({"status", "message", "result"})
 public record SuccessResponse<T>(
-        boolean isSuccess,
-        int code,
+        int status,
         String message,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         T result
 ) {
     public static <T> SuccessResponse of(SuccessMessage successMessage){
-        return new SuccessResponse(successMessage.isSuccess(), successMessage.getStatus(), successMessage.getMessage(), null);
+        return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), null);
     }
 
     public static <T> SuccessResponse of(SuccessMessage successMessage, T result){
-        return new SuccessResponse(successMessage.isSuccess(), successMessage.getStatus(), successMessage.getMessage(), result);
+        return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), result);
     }
 }

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -7,14 +7,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    SUCCESS_CREATE_CATEGORY(201, true, "카테고리를 성공적으로 추가하였습니다."),
-    SUCCESS_GET_CATEGORIES(200, true, "카테고리 리스트 조회를 성공하였습니다."),
-    SUCCESS_CREATE_WORD(201, true, "단어를 성공적으로 추가하였습니다."),
-    SUCCESS_GET_WORDS(200, true, "단어 리스트 조회를 성공하였습니다."),
-    SUCCESS_GET_WORD(200, true, "특정 단어 조회를 성공하였습니다.");
+    SUCCESS_CREATE_CATEGORY(201,  "카테고리를 성공적으로 추가하였습니다."),
+    SUCCESS_GET_CATEGORIES(200,  "카테고리 리스트 조회를 성공하였습니다."),
+    SUCCESS_CREATE_WORD(201, "단어를 성공적으로 추가하였습니다."),
+    SUCCESS_GET_WORDS(200,  "단어 리스트 조회를 성공하였습니다."),
+    SUCCESS_GET_WORD(200, "특정 단어 조회를 성공하였습니다.");
 
     private final int status;
-    private final boolean success;
     private final String message;
 
 }


### PR DESCRIPTION
# 📄 Work Description
- 성공/에러 메시지 필드 및 enum 수정

# ⚙️ ISSUE
- closed #20 


# 📷 Screenshot
 - 따로 없음


# 💬 To Reviewers

>  7/9일 서버-클라이언트 로그인 회의 후 나온 수정사항들을 반영했습니다!

1. 성공 및 에러 메시지 필드 수정
- 성공시 : status, message, result
- 실패시: status, result
- 수정 사항) 
  1. 필드명 code > status로 수정 / 이유: 조금 더 직관적이고 이해가 잘되는 필드명 사용을 위해
  2. validation 예외 발생시 사용되던 errors 필드 삭제 (ErrorResponse 클래스) / 이유: 2차 스프린트로 미루기로 

https://github.com/teamterning/Terning-Server/blob/705591457ddef35b87c7075340daad91e4681b4e/src/main/java/org/terning/terningserver/exception/dto/ErrorResponse.java#L11-L15

https://github.com/teamterning/Terning-Server/blob/705591457ddef35b87c7075340daad91e4681b4e/src/main/java/org/terning/terningserver/exception/dto/SuccessResponse.java#L7-L12

2. enum 타입 수정
- 클라 - 서버 통신에 있어서 받고 보내는 인덱스 값은 무조건 0부터 보내기로 수정하였습니다!
 -  이유: 클라에서 0부터 설정하는게 조금 더 편하다고 하셔서!


# 🔗 Reference
자세한 회의 내용은 👉[노션](https://abundant-quiver-13f.notion.site/ee2af18d5ed249439cfa80c13a480e5c?pvs=4)에 정리해두었습니다!