### PR TITLE
[✨feat/#27] 탐색 > 스크랩 수 많은 공고 API 구현

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/SearchController.java
+++ b/src/main/java/org/terning/terningserver/controller/SearchController.java
@@ -12,6 +12,7 @@ import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.SearchService;
 
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS;
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS;
 
 
@@ -28,6 +29,15 @@ public class SearchController implements SearchSwagger {
         return ResponseEntity.ok(SuccessResponse.of(
                 SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS,
                 searchService.getMostViewedAnnouncements()
+        ));
+    }
+
+    @GetMapping("/search/scraps")
+    public ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostScrappedAnnouncements() {
+
+        return ResponseEntity.ok(SuccessResponse.of(
+                SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS,
+                searchService.getMostScrappedAnnouncements()
         ));
     }
 

--- a/src/main/java/org/terning/terningserver/controller/SearchController.java
+++ b/src/main/java/org/terning/terningserver/controller/SearchController.java
@@ -11,6 +11,9 @@ import org.terning.terningserver.dto.search.response.PopularAnnouncementListResp
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.SearchService;
+import org.terning.terningserver.util.DateUtil;
+
+import java.time.LocalDate;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS;
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS;
@@ -34,7 +37,6 @@ public class SearchController implements SearchSwagger {
 
     @GetMapping("/search/scraps")
     public ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostScrappedAnnouncements() {
-
         return ResponseEntity.ok(SuccessResponse.of(
                 SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS,
                 searchService.getMostScrappedAnnouncements()

--- a/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
@@ -20,4 +20,12 @@ public interface SearchSwagger {
     ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostViewedAnnouncements(
 
     );
+
+    @Operation(summary = "탐색 > 지금 스크랩 수 많은 공고", description = "탐색 화면에서 스크랩 수 많은 공고를 불러오는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content(mediaType = "application/json"))
+    })
+    ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostScrappedAnnouncements(
+
+    );
 }

--- a/src/main/java/org/terning/terningserver/domain/Filter.java
+++ b/src/main/java/org/terning/terningserver/domain/Filter.java
@@ -26,6 +26,7 @@ public class Filter {
     @Column(nullable = false)
     private WorkingPeriod workingPeriod;
 
-    @Column(nullable = false)
-    private YearMonth startDate;
+    private int startYear;
+
+    private int startMonth;
 }

--- a/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
+++ b/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
@@ -31,7 +31,11 @@ public class InternshipAnnouncement extends BaseTimeEntity {
     @Column(length = 16)
     private String workingPeriod;  // 근무 기간
 
-    private YearMonth startDate;  // 시작 날짜
+    @Column(nullable = false)
+    private int startYear;
+
+    @Column(nullable = false)
+    private int startMonth;
 
     @Column(nullable = false)
     private int viewCount;  // 조회 수

--- a/src/main/java/org/terning/terningserver/domain/User.java
+++ b/src/main/java/org/terning/terningserver/domain/User.java
@@ -37,7 +37,8 @@ public class User extends BaseTimeEntity {
 
 //    private String email; //이메일
 
-//    private String userImage; //유저 아이콘
+    @Column(nullable = false)
+    private int profileImage;
 
     @Enumerated(STRING)
     @Column(nullable = false)

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -7,15 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    SUCCESS_CREATE_CATEGORY(201,  "카테고리를 성공적으로 추가하였습니다."),
-    SUCCESS_GET_CATEGORIES(200,  "카테고리 리스트 조회를 성공하였습니다."),
-    SUCCESS_CREATE_WORD(201, "단어를 성공적으로 추가하였습니다."),
-    SUCCESS_GET_WORDS(200,  "단어 리스트 조회를 성공하였습니다."),
-    SUCCESS_GET_WORD(200, "특정 단어 조회를 성공하였습니다."),
-
     // Search (탐색 화면)
-    SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS(200, "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다."),
-    SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS(200, "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다.");
+    SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS(200, "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다"),
+    SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS(200, "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다");
 
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -14,7 +14,8 @@ public enum SuccessMessage {
     SUCCESS_GET_WORD(200, "특정 단어 조회를 성공하였습니다."),
 
     // Search (탐색 화면)
-    SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS(200, "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다."),;
+    SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS(200, "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다."),
+    SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS(200, "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다.");
 
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/repository/InternshipAnnouncement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/InternshipAnnouncement/InternshipRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface InternshipRepositoryCustom {
     List<InternshipAnnouncement> getMostViewedInternship();
+    List<InternshipAnnouncement> getMostScrappedInternship();
 }

--- a/src/main/java/org/terning/terningserver/repository/InternshipAnnouncement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/InternshipAnnouncement/InternshipRepositoryImpl.java
@@ -28,6 +28,18 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<InternshipAnnouncement> getMostScrappedInternship() {
+        return jpaQueryFactory
+                .selectFrom(internshipAnnouncement)
+                .where(
+                        internDeadlineGoe(),
+                        internCreatedAtAfter()
+                ) //지원 마감된 공고 및 30일 보다 오래된 공고 제외
+                .orderBy(internshipAnnouncement.scrapCount.desc(), internshipAnnouncement.createdAt.desc())
+                .fetch();
+    }
+
     private BooleanExpression internDeadlineGoe() {
         return internshipAnnouncement.deadline.goe(LocalDate.now());
     }

--- a/src/main/java/org/terning/terningserver/repository/InternshipAnnouncement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/InternshipAnnouncement/InternshipRepositoryImpl.java
@@ -40,10 +40,12 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .fetch();
     }
 
+    //지원 마감일이 지나지 않은 공고
     private BooleanExpression internDeadlineGoe() {
         return internshipAnnouncement.deadline.goe(LocalDate.now());
     }
 
+    // 현재 시점으로부터 30일 이내의 공고
     private BooleanExpression internCreatedAtAfter() {
         return internshipAnnouncement.createdAt.after(LocalDate.now().minusDays(30).atStartOfDay());
     }

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -22,4 +22,9 @@ public class SearchService {
         return PopularAnnouncementListResponse.of(mostViewedInternships);
     }
 
+    public PopularAnnouncementListResponse getMostScrappedAnnouncements() {
+        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostViewedInternship();
+        return PopularAnnouncementListResponse.of(mostViewedInternships);
+    }
+
 }

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
 import org.terning.terningserver.repository.InternshipAnnouncement.InternshipRepository;
+import org.terning.terningserver.util.DateUtil;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -25,7 +25,7 @@ public class SearchService {
     }
 
     public PopularAnnouncementListResponse getMostScrappedAnnouncements() {
-        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostViewedInternship();
+        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostScrappedInternship();
         return PopularAnnouncementListResponse.of(mostViewedInternships);
     }
 

--- a/src/main/java/org/terning/terningserver/util/DateUtil.java
+++ b/src/main/java/org/terning/terningserver/util/DateUtil.java
@@ -1,0 +1,28 @@
+package org.terning.terningserver.util;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoLocalDate;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class DateUtil {
+
+    public static String convert(LocalDate deadline) {
+        ZonedDateTime nowInKorea = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDate currentDate = nowInKorea.toLocalDate();
+
+        if (deadline.isEqual(currentDate)) {
+            return "D-DAY";
+        } else if (deadline.isBefore(currentDate)) {
+            return "지원마감";
+        } else {
+            long daysUntilDeadline = currentDate.until(deadline).getDays();
+            return "D-" + daysUntilDeadline;
+        }
+    }
+}
+


### PR DESCRIPTION
# 📄 Work Description
- 탐색 > 스크랩 수 많은 공고 API입니다.

# ⚙️ ISSUE
- closed #27 


# 📷 Screenshot
 - swagger 문서
<img width="800" alt="image" src="https://github.com/teamterning/Terning-Server/assets/63058347/e43a81c2-2fbc-4235-8993-138759f84cb2">
<br/>
<br/>

- postman 실행 화면
<img width="500" alt="스크린샷 2024-07-11 오후 11 55 00" src="https://github.com/teamterning/Terning-Server/assets/63058347/ec549a9e-6487-4940-8d58-a02a48f10546">


# 💬 To Reviewers
1. D-Day 계산을 위한 DateUtil 클래스 생성
- 현재 시점이 마감일 보다 이전일 경우 D-Day 계산해서 반환
- 현재 시점이 마감일과 같으면 "D-DAY" 문자열 반환
- 현재 시점이 마감일 이후인 경우 "지원마감" 반환
https://github.com/teamterning/Terning-Server/blob/74af5380daffbd61810e0a35f515afcdc7ef46bb/src/main/java/org/terning/terningserver/util/DateUtil.java#L14-L27

그 외 로직은 👉 closed #26 와 같습니다!

## 📣 테이블 수정사항
1. User 엔티티 -> 프로필 이미지 캐릭터 필드 추가
https://github.com/teamterning/Terning-Server/blob/1fdee68b7020f67b402bb5580050100dbe1f5e4a/src/main/java/org/terning/terningserver/domain/User.java#L40-L41

2. InternshipAnnouncement, Filter 엔티티 기존의 startDate를 startYear, startMonth로 분리
https://github.com/teamterning/Terning-Server/blob/1fdee68b7020f67b402bb5580050100dbe1f5e4a/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java#L34-L38
https://github.com/teamterning/Terning-Server/blob/1fdee68b7020f67b402bb5580050100dbe1f5e4a/src/main/java/org/terning/terningserver/domain/Filter.java#L29-L31



# 🔗 Reference
