### PR TITLE
[✨feat/#33] 홈화면 > 오늘 마감되는 대학생 인턴 공고 API

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -5,11 +5,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.HomeSwagger;
 import org.terning.terningserver.dto.user.response.HomeResponseDto;
+import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
+import org.terning.terningserver.exception.CustomException;
+import org.terning.terningserver.exception.dto.ErrorResponse;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.HomeService;
+import org.terning.terningserver.service.ScrapService;
 
 import java.util.List;
+
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_ANNOUNCEMENTS;
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_TODAY_ANNOUNCEMENTS;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +24,7 @@ import java.util.List;
 public class HomeController implements HomeSwagger {
 
     private final HomeService homeService;
+    private final ScrapService scrapService;
 
     @GetMapping("/home")
     public ResponseEntity<SuccessResponse<List<HomeResponseDto>>> getAnnouncements(
@@ -26,6 +34,20 @@ public class HomeController implements HomeSwagger {
             @RequestParam("startMonth") int startMonth
     ){
         List<HomeResponseDto> announcements = homeService.getAnnouncements(token, sortBy, startYear, startMonth);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.SUCCESS_GET_ANNOUNCEMENTS, announcements));
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
+    }
+
+    @GetMapping("/home/today")
+    public ResponseEntity<SuccessResponse<List<TodayScrapResponseDto>>> getTodayScraps(
+            @RequestHeader("Authorization") String token
+    ){
+        Long userId = getUserIdFromToken(token);
+        List<TodayScrapResponseDto> scrapList = scrapService.getTodayScrap(userId);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_TODAY_ANNOUNCEMENTS, scrapList));
+    }
+
+    private Long getUserIdFromToken(String token){
+        //실제 토큰에서 userId를 가져오는 로직 구현
+        return 1L; //임시로 사용자 ID 1로 반환
     }
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.terning.terningserver.dto.user.response.HomeResponseDto;
+import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
 import java.util.List;
@@ -15,14 +16,15 @@ import java.util.List;
 public interface HomeSwagger {
 
     @Operation(summary = "홈화면 > 나에게 딱맞는 인턴 공고 조회", description = "특정 사용자에 필터링 조건에 맞는 인턴 공고 정보를 조회하는 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "인턴 공고를 성공적으로 조회했습니다.", content =
-            @Content(mediaType = "application/json"))
-    })
     ResponseEntity<SuccessResponse<List<HomeResponseDto>>> getAnnouncements(
         String token,
         String sortBy,
         int startYear,
         int startMonth
+    );
+
+    @Operation(summary = "홈화면 > 오늘 마감인 스크랩 공고 조회", description = "오늘 마감인 스크랩 공고를 조회하는 API")
+    ResponseEntity<SuccessResponse<List<TodayScrapResponseDto>>> getTodayScraps(
+            String token
     );
 }

--- a/src/main/java/org/terning/terningserver/domain/enums/Color.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Color.java
@@ -19,4 +19,8 @@ public enum Color {
 
     private final int key;
     private final String value;
+
+    public String getColorValue() {
+        return "#" + value;
+    }
 }

--- a/src/main/java/org/terning/terningserver/dto/user/response/TodayScrapResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/TodayScrapResponseDto.java
@@ -1,0 +1,34 @@
+package org.terning.terningserver.dto.user.response;
+
+import lombok.Builder;
+import org.terning.terningserver.domain.Scrap;
+import org.terning.terningserver.util.DateUtil;
+
+@Builder
+public record TodayScrapResponseDto(
+        Long scrapId,
+        Long internshipAnnouncementId,
+        String companyImage,
+        String title,
+        String dDay,
+        String deadline,
+        String workingPeriod,
+        String startYearMonth,
+        String color
+) {
+    public static TodayScrapResponseDto of(final Scrap scrap){
+        String startYearMonth = scrap.getInternshipAnnouncement().getStartYear() + "년 " + scrap.getInternshipAnnouncement().getStartMonth() + "월";
+
+        return TodayScrapResponseDto.builder()
+                .scrapId(scrap.getId())
+                .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
+                .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
+                .title(scrap.getInternshipAnnouncement().getTitle())
+                .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
+                .deadline(DateUtil.convertDeadline(scrap.getInternshipAnnouncement().getDeadline()))
+                .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
+                .startYearMonth(startYearMonth)
+                .color(scrap.getColor().getColorValue())
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum SuccessMessage {
     // 홈 화면
     SUCCESS_GET_ANNOUNCEMENTS(200, "인턴 공고 불러오기를 성공했습니다"),
-
+    SUCCESS_GET_TODAY_ANNOUNCEMENTS(200, "오늘 마감인 인턴 공고 요청을 성공했습니다"),
 
     // Search (탐색 화면)
     SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS(200, "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다"),

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
@@ -3,9 +3,12 @@ package org.terning.terningserver.repository.scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.terning.terningserver.domain.Scrap;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     Boolean existsByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
+    List<Scrap> findByUserIdAndInternshipAnnouncement_Deadline(Long userId, LocalDate deadline);
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRespository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRespository.java
@@ -1,9 +1,0 @@
-package org.terning.terningserver.repository.scrap;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.terning.terningserver.domain.Scrap;
-
-public interface ScrapRespository extends JpaRepository<Scrap, Long> {
-
-    Boolean existsByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
-}

--- a/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
@@ -8,7 +8,7 @@ import org.terning.terningserver.dto.user.response.HomeResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.exception.enums.ErrorMessage;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
-import org.terning.terningserver.repository.scrap.ScrapRespository;
+import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
 
 import java.util.List;
@@ -20,7 +20,7 @@ public class HomeServiceImpl implements HomeService{
 
     private final InternshipRepository internshipRepository;
     private final UserRepository userRepository;
-    private final ScrapRespository scrapRepository;
+    private final ScrapRepository scrapRepository;
 
     @Override
     public List<HomeResponseDto> getAnnouncements(String token, String sortBy, int startYear, int startMonth){

--- a/src/main/java/org/terning/terningserver/service/ScrapService.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapService.java
@@ -1,0 +1,9 @@
+package org.terning.terningserver.service;
+
+import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
+
+import java.util.List;
+
+public interface ScrapService {
+    List<TodayScrapResponseDto> getTodayScrap(Long userId);
+}

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -1,0 +1,25 @@
+package org.terning.terningserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
+import org.terning.terningserver.repository.scrap.ScrapRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapServiceImpl implements ScrapService {
+
+    private final ScrapRepository scrapRepository;
+
+    @Override
+    public List<TodayScrapResponseDto> getTodayScrap(Long userId){
+        LocalDate today = LocalDate.now();
+        return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, today).stream()
+                .map(TodayScrapResponseDto::of)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
### 홈화면 > 오늘 마감되는 대학생 인턴 공고 API
- 유저가 스크랩한 공고 중 마감 기한이 오늘(오늘 마감)인 공고데이터의 공고명을 보여준다.
- 보여주는 데이터는 경우의 수가 2가지 있다.
(1) 스크랩된 공고가 없는 경우 & 스크랩된 공고가 있으나, 오늘 마감인 공고가 없는 경우 : 빈 리스트를 반환한다.
(2) 스크랩된 공고가 존재하고, 마감 기한이 오늘인 스크랩 공고도 존재하는 경우 : 유저가 스크랩한 공고 중 서류지원 마감일이 ‘오늘’인 공고 데이터의 스크랩 ID, 인턴쉽 공고ID 와 기업로고 url, title(공고명), dDay, 서류마감, 근무 기간, 근무 시작 년월, 스크랩 색상을 응답으로 준다.


# ⚙️ ISSUE
- closed #33 


# 📷 Screenshot
 > Case 1) 스크랩된 공고 가 없는 경우 & 스크랩된 공고가 있으나, 오늘 마감인 공고가 없는 경우 : 빈 리스트 반환
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/78146b53-2119-4649-8593-5dbb1a5969a3">


<br/>

> Case 2) 스크랩된 공고가 존재하고, 마감 기한이 오늘인 스크랩 공고도 존재하는 경우 : 유저가 스크랩한 공고 중 서류지원 마감일이 ‘오늘’인 공고 데이터의 스크랩 ID, 인턴쉽 공고ID 와 기업로고 url, title(공고명), dDay, 서류마감, 근무 기간, 근무 시작 년월, 스크랩 색상을 응답으로 준다.
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/41c1f165-3b3b-4466-83ce-fc182d23538f">
<img width="1413" alt="image" src="https://github.com/user-attachments/assets/19d2b438-281c-4a59-b44e-870bb472f996">



# 💬 To Reviewers


# 🔗 Reference
