### PR TITLE
[✨feat/#36] 캘린더 > 월간 캘린더(기본 뷰) 정보 조회 API

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/CalendarController.java
+++ b/src/main/java/org/terning/terningserver/controller/CalendarController.java
@@ -1,0 +1,37 @@
+package org.terning.terningserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.terning.terningserver.controller.swagger.CalendarSwagger;
+import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
+import org.terning.terningserver.exception.dto.SuccessResponse;
+import org.terning.terningserver.service.ScrapService;
+
+import java.util.List;
+
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MONTHLY_SCRAPS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class CalendarController implements CalendarSwagger {
+
+    private final ScrapService scrapService;
+
+    @GetMapping("/calendar/monthly-default")
+    public ResponseEntity<SuccessResponse<List<MonthlyDefaultResponseDto>>> getMonthlyScraps(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("year") int year,
+            @RequestParam("month") int month
+    ){
+        Long userId = getUserIdFromToken(token);
+        List<MonthlyDefaultResponseDto> monthlyScraps = scrapService.getMonthlyScraps(userId, year, month);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_MONTHLY_SCRAPS, monthlyScraps));
+    }
+
+    private Long getUserIdFromToken(String token){
+        //실제 토큰에서 userId를 받아오는 로직 구현
+        return 1L;  //임시로 사용자 ID 1로 반환
+    }
+}

--- a/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
@@ -1,0 +1,21 @@
+package org.terning.terningserver.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
+import org.terning.terningserver.exception.dto.SuccessResponse;
+
+import java.time.Month;
+import java.util.List;
+
+@Tag(name = "Calendar", description = "캘린더 관련 API")
+public interface CalendarSwagger {
+
+    @Operation(summary = "캘린더 > 월간 스크랩 공고 조회", description = "월간 스크랩 공고를 조회하는 API")
+    ResponseEntity<SuccessResponse<List<MonthlyDefaultResponseDto>>> getMonthlyScraps(
+            String token,
+            int year,
+            int month
+    );
+}

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyDefaultResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyDefaultResponseDto.java
@@ -1,0 +1,34 @@
+package org.terning.terningserver.dto.calendar.response;
+
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MonthlyDefaultResponseDto(
+        String deadline,
+        List<ScrapDetail> scraps
+) {
+    @Builder
+    public static record ScrapDetail(
+            Long scrapId,
+            String title,
+            String color
+    ){
+        public static ScrapDetail of(Long scrapId, String title, String color){
+            return ScrapDetail.builder()
+                    .scrapId(scrapId)
+                    .title(title)
+                    .color(color)
+                    .build();
+        }
+    }
+
+    public static MonthlyDefaultResponseDto of(String deadline, List<ScrapDetail> scraps){
+        return MonthlyDefaultResponseDto.builder()
+                .deadline(deadline)
+                .scraps(scraps)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -10,7 +10,6 @@ public enum ErrorMessage {
     //404(NotFound)
     NOT_FOUND_INTERN_CATEGORY(404, "해당 인턴 공고는 존재하지 않습니다"),
     NOT_FOUND_INTERN_EXCEPTION(404, "해당 인턴 공고는 존재하지 않습니다"),
-    WRONG_PERIOD(404, "해당 단어가 존재하지 않습니다"),
     NOT_FOUND_USER_EXCEPTION(404, "해당 유저가 존재하지 않습니다");
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -15,7 +15,10 @@ public enum SuccessMessage {
     SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS(200, "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다"),
 
     // 인턴 공고
-    SUCCESS_GET_INTERNSHIP_DETAIL(200, "공고 상세 정보 불러오기에 성공했습니다");
+    SUCCESS_GET_INTERNSHIP_DETAIL(200, "공고 상세 정보 불러오기에 성공했습니다"),
+
+    // Calendar (캘린더 화면)
+    SUCCESS_GET_MONTHLY_SCRAPS(200, "캘린더 > (월간) 스크랩 된 공고 정보 불러오기를 성공했습니다");
     ;
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
@@ -11,4 +11,5 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     Boolean existsByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
     List<Scrap> findByUserIdAndInternshipAnnouncement_Deadline(Long userId, LocalDate deadline);
+    List<Scrap> findByUserIdAndInternshipAnnouncement_DeadlineBetween(Long userId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/org/terning/terningserver/service/ScrapService.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapService.java
@@ -1,9 +1,11 @@
 package org.terning.terningserver.service;
 
+import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 
 import java.util.List;
 
 public interface ScrapService {
     List<TodayScrapResponseDto> getTodayScrap(Long userId);
+    List<MonthlyDefaultResponseDto> getMonthlyScraps(Long userId, int year, int month);
 }

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -2,11 +2,14 @@ package org.terning.terningserver.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.terning.terningserver.domain.Scrap;
+import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.repository.scrap.ScrapRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,5 +24,32 @@ public class ScrapServiceImpl implements ScrapService {
         return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, today).stream()
                 .map(TodayScrapResponseDto::of)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<MonthlyDefaultResponseDto> getMonthlyScraps(Long userId, int year, int month){
+
+        //모든 월의 시작일은 1, 마지막일은 해당 다음월의 하루
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.plusMonths(1).minusDays(1);
+
+        List<Scrap> scraps = scrapRepository.findByUserIdAndInternshipAnnouncement_DeadlineBetween(userId, start, end);
+
+        // deadline 별로 그룹화
+        Map<LocalDate, List<Scrap>> scrapsByDeadline = scraps.stream()
+                .collect(Collectors.groupingBy(s -> s.getInternshipAnnouncement().getDeadline()));
+
+        return scrapsByDeadline.entrySet().stream()
+                .map(entry -> MonthlyDefaultResponseDto.of(
+                        entry.getKey().toString(),
+                        entry.getValue().stream()
+                                .map(s -> MonthlyDefaultResponseDto.ScrapDetail.of(
+                                        s.getId(),
+                                        s.getInternshipAnnouncement().getTitle(),
+                                        s.getColor().getColorValue()
+                                ))
+                                .toList()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -23,7 +23,7 @@ public class ScrapServiceImpl implements ScrapService {
         LocalDate today = LocalDate.now();
         return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, today).stream()
                 .map(TodayScrapResponseDto::of)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -29,7 +29,7 @@ public class ScrapServiceImpl implements ScrapService {
     @Override
     public List<MonthlyDefaultResponseDto> getMonthlyScraps(Long userId, int year, int month){
 
-        //모든 월의 시작일은 1, 마지막일은 해당 다음월의 하루
+        //모든 월의 시작일은 1, 마지막일은 해당 다음월의 하루 전
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.plusMonths(1).minusDays(1);
 


### PR DESCRIPTION
# 📄 Work Description
### 캘린더 > 월간 캘린더(기본 뷰) 정보 조회 API
- 조회하고자 하는 연도와 월을 입력합니다. 
- 해당하는 년/월의 스크랩한 공고를 deadline별로 그룹화 하여 월간 캘린더(기본 뷰) 정보를 조회합니다. 
- 만약 조회했을 때, 해당하는 스크랩 공고가 없을 경우, 빈 리스트가 조회됩니다.

# ⚙️ ISSUE
- closed #36 


# 📷 Screenshot
 - Swagger(200 성공)
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/bd581711-c615-4b5d-8534-800387889d91">
<img width="1420" alt="image" src="https://github.com/user-attachments/assets/e7aa2213-baa4-4ec8-b142-4c437cf08ae8">
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/8c5b2130-0e2f-49ac-9d35-8b0770679dad">



# 💬 To Reviewers
- 캘린더 뷰를 담당하는 클라분과 상의 한 결과, 해당 하는 년/월이 서류마감일인 스크랩 공고를 순서대로 띄우는 것과 deadline(서류 마감일) 기준으로 묶어서 정보를 보내주는 과정을 고민했습니다. 
- 리스트로 전달하는 과정에서 stream을 사용하는데, stream 옵션중 최종 단계에서 사용되는 Java Collector인 Stream.collect() stream 요소들을 공부하던 중, 'Collectors.groupingBy()' 를 알게 되었습니다. Collectors.groupingBy() 옵션은 요소를 그룹핑해서 수집하는 역할을 합니다.
- groupingBy collector는 일부 속성 별로 객체를 grouping하고 결과를 Map 인스턴스에 저장하는 데 사용한다고 하여 Map 인스턴스를 활용해 구현했습니다.
https://github.com/teamterning/Terning-Server/blob/890fffed615aa3fd18be60b8d84ae8185f99f747/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java#L38-L54
- 학습을 하면서 참고했던 블로그 링크를 첨부하겠습니다:)


# 🔗 Reference
- [stream 마지막 단계 - Collectors.groupingBy()](https://velog.io/@jyleedev/groupingby-mapping)
- [[Java] Stream 데이터 groupingBy 예제](https://umanking.github.io/2021/07/31/java-stream-grouping-by-example/)
