### PR TITLE
[✨feat/#31] 검색 결과 화면 API

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/SearchController.java
+++ b/src/main/java/org/terning/terningserver/controller/SearchController.java
@@ -2,20 +2,22 @@ package org.terning.terningserver.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.terning.terningserver.controller.swagger.SearchSwagger;
+import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.SearchService;
 import org.terning.terningserver.util.DateUtil;
 
-import java.awt.print.Pageable;
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS;
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS;
@@ -46,10 +48,10 @@ public class SearchController implements SearchSwagger {
     }
 
     @GetMapping("/search")
-    public void searchInternshipAnnouncement(
-            @RequestParam String keyword,
-            @RequestParam String sortBy, Pageable pageable) {
-        searchService.searchInternshipAnnouncement(keyword, sortBy, pageable);
+    public List<InternshipAnnouncement> searchInternshipAnnouncement(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam("sortBy") String sortBy, Pageable pageable) {
+        return searchService.searchInternshipAnnouncement(keyword, sortBy, pageable);
     }
 
 }

--- a/src/main/java/org/terning/terningserver/controller/SearchController.java
+++ b/src/main/java/org/terning/terningserver/controller/SearchController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.terning.terningserver.controller.swagger.SearchSwagger;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
@@ -13,6 +14,7 @@ import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.SearchService;
 import org.terning.terningserver.util.DateUtil;
 
+import java.awt.print.Pageable;
 import java.time.LocalDate;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS;
@@ -41,6 +43,13 @@ public class SearchController implements SearchSwagger {
                 SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS,
                 searchService.getMostScrappedAnnouncements()
         ));
+    }
+
+    @GetMapping("/search")
+    public void searchInternshipAnnouncement(
+            @RequestParam String keyword,
+            @RequestParam String sortBy, Pageable pageable) {
+        searchService.searchInternshipAnnouncement(keyword, sortBy, pageable);
     }
 
 }

--- a/src/main/java/org/terning/terningserver/controller/SearchController.java
+++ b/src/main/java/org/terning/terningserver/controller/SearchController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.terning.terningserver.controller.swagger.SearchSwagger;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
+import org.terning.terningserver.dto.search.response.SearchResultResponse;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.SearchService;
@@ -48,7 +49,7 @@ public class SearchController implements SearchSwagger {
     }
 
     @GetMapping("/search")
-    public List<InternshipAnnouncement> searchInternshipAnnouncement(
+    public SearchResultResponse searchInternshipAnnouncement(
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam("sortBy") String sortBy, Pageable pageable) {
         return searchService.searchInternshipAnnouncement(keyword, sortBy, pageable);

--- a/src/main/java/org/terning/terningserver/controller/SearchController.java
+++ b/src/main/java/org/terning/terningserver/controller/SearchController.java
@@ -20,8 +20,7 @@ import org.terning.terningserver.util.DateUtil;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS;
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS;
+import static org.terning.terningserver.exception.enums.SuccessMessage.*;
 
 
 @RestController
@@ -49,10 +48,13 @@ public class SearchController implements SearchSwagger {
     }
 
     @GetMapping("/search")
-    public SearchResultResponse searchInternshipAnnouncement(
+    public ResponseEntity<SuccessResponse<SearchResultResponse>> searchInternshipAnnouncement(
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam("sortBy") String sortBy, Pageable pageable) {
-        return searchService.searchInternshipAnnouncement(keyword, sortBy, pageable);
+        return ResponseEntity.ok(SuccessResponse.of(
+                SUCCESS_GET_SEARCH_ANNOUNCEMENTS,
+                searchService.searchInternshipAnnouncement(keyword, sortBy, pageable)
+        ));
     }
 
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
+import org.terning.terningserver.dto.search.response.SearchResultResponse;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
 @Tag(name = "Search", description = "탐색 관련 API")
@@ -20,6 +21,11 @@ public interface SearchSwagger {
 
     @Operation(summary = "탐색 > 지금 스크랩 수 많은 공고", description = "탐색 화면에서 스크랩 수 많은 공고를 불러오는 API")
     ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostScrappedAnnouncements(
+
+    );
+
+    @Operation(summary = "탐색 > 검색 결과 화면", description = "탐색 화면에서 인턴 공고를 검색하는 API")
+    ResponseEntity<SuccessResponse<SearchResultResponse>> searchInternshipAnnouncement(
 
     );
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
@@ -14,17 +14,11 @@ import org.terning.terningserver.exception.dto.SuccessResponse;
 public interface SearchSwagger {
 
     @Operation(summary = "탐색 > 지금 조회수 많은 공고", description = "탐색 화면에서 조회수 많은 공고를 불러오는 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content(mediaType = "application/json"))
-    })
     ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostViewedAnnouncements(
 
     );
 
     @Operation(summary = "탐색 > 지금 스크랩 수 많은 공고", description = "탐색 화면에서 스크랩 수 많은 공고를 불러오는 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content(mediaType = "application/json"))
-    })
     ResponseEntity<SuccessResponse<PopularAnnouncementListResponse>> getMostScrappedAnnouncements(
 
     );

--- a/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/SearchSwagger.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
 import org.terning.terningserver.dto.search.response.SearchResultResponse;
 import org.terning.terningserver.exception.dto.SuccessResponse;
@@ -26,6 +28,7 @@ public interface SearchSwagger {
 
     @Operation(summary = "탐색 > 검색 결과 화면", description = "탐색 화면에서 인턴 공고를 검색하는 API")
     ResponseEntity<SuccessResponse<SearchResultResponse>> searchInternshipAnnouncement(
-
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam("sortBy") String sortBy, Pageable pageable
     );
 }

--- a/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
+++ b/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
@@ -46,6 +46,9 @@ public class InternshipAnnouncement extends BaseTimeEntity {
     @Column(nullable = false, length = 256)
     private String url;  // 인턴십 공고 URL
 
+    @OneToMany(mappedBy = "internshipAnnouncement")
+    private List<Scrap> scraps;
+
     @Embedded
     private Company company;
 

--- a/src/main/java/org/terning/terningserver/domain/Scrap.java
+++ b/src/main/java/org/terning/terningserver/domain/Scrap.java
@@ -26,7 +26,7 @@ public class Scrap extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 스크랩한 사용자
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "internshipAnnouncement_id", nullable = false)
     private InternshipAnnouncement internshipAnnouncement; // 스크랩한 인턴십 공고
 

--- a/src/main/java/org/terning/terningserver/domain/User.java
+++ b/src/main/java/org/terning/terningserver/domain/User.java
@@ -32,23 +32,20 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Scrap> scrapList = new ArrayList<>(); // 스크랩 공고
 
-    @Column(nullable = false, length = 12)
+    @Column(length = 12)
     private String name; // 사용자 이름
 
 //    private String email; //이메일
 
-    @Column(nullable = false)
     private int profileImage;
 
     @Enumerated(STRING)
-    @Column(nullable = false)
     private AuthType authType; // 인증 유형 (예: 카카오, 애플)
 
-    @Column(nullable = false, length = 256)
+    @Column(length = 256)
     private String authId; // 인증 서비스에서 제공하는 고유 ID
 
     @Enumerated(STRING)
-    @Column(nullable = false)
     private State state; // 사용자 상태 (예: 활성, 비활성, 정지)
 
 }

--- a/src/main/java/org/terning/terningserver/domain/enums/Grade.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Grade.java
@@ -1,8 +1,9 @@
 package org.terning.terningserver.domain.enums;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-
+@Getter
 @RequiredArgsConstructor
 public enum Grade {
     FRESHMAN(0, "1학년"),

--- a/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
+++ b/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
@@ -1,0 +1,6 @@
+package org.terning.terningserver.dto.search.response;
+
+public record SearchResultResponse(
+
+) {
+}

--- a/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
+++ b/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public record SearchResultResponse(
+        int totalPages,
+        Boolean hasNext,
         List<SearchAnnouncementResponse> announcements
 ) {
     @Builder
@@ -32,7 +34,8 @@ public record SearchResultResponse(
         }
     }
     public static SearchResultResponse of(List<SearchAnnouncementResponse> announcements) {
-        return new SearchResultResponse(announcements);
+    public static SearchResultResponse of(int totalPages, Boolean hasNext, List<SearchAnnouncementResponse> announcements) {
+        return new SearchResultResponse(totalPages, hasNext, announcements);
     }
 
 }

--- a/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
+++ b/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
@@ -33,7 +33,6 @@ public record SearchResultResponse(
                     .build();
         }
     }
-    public static SearchResultResponse of(List<SearchAnnouncementResponse> announcements) {
     public static SearchResultResponse of(int totalPages, Boolean hasNext, List<SearchAnnouncementResponse> announcements) {
         return new SearchResultResponse(totalPages, hasNext, announcements);
     }

--- a/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
+++ b/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
@@ -17,10 +17,9 @@ public record SearchResultResponse(
             String dDay,
             String companyImage,
             String title,
-            String workingPeriod,
-            Boolean isScrapped
+            String workingPeriod
     ) {
-        public static SearchAnnouncementResponse from(InternshipAnnouncement announcement, Long scrapId, Boolean isScrapped) {
+        public static SearchAnnouncementResponse from(InternshipAnnouncement announcement, Long scrapId) {
             return SearchAnnouncementResponse.builder()
                     .internshipAnnouncementId(announcement.getId())
                     .scrapId(scrapId)
@@ -28,7 +27,7 @@ public record SearchResultResponse(
                     .companyImage(announcement.getCompany().getCompanyImage())
                     .title(announcement.getTitle())
                     .workingPeriod(announcement.getWorkingPeriod())
-                    .isScrapped(isScrapped)
+//                    .isScrapped(isScrapped)
                     .build();
         }
     }

--- a/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
+++ b/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponse.java
@@ -1,6 +1,39 @@
 package org.terning.terningserver.dto.search.response;
 
-public record SearchResultResponse(
+import lombok.Builder;
+import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.util.DateUtil;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record SearchResultResponse(
+        List<SearchAnnouncementResponse> announcements
 ) {
+    @Builder
+    public record SearchAnnouncementResponse(
+            Long internshipAnnouncementId,
+            Long scrapId,
+            String dDay,
+            String companyImage,
+            String title,
+            String workingPeriod,
+            Boolean isScrapped
+    ) {
+        public static SearchAnnouncementResponse from(InternshipAnnouncement announcement, Long scrapId, Boolean isScrapped) {
+            return SearchAnnouncementResponse.builder()
+                    .internshipAnnouncementId(announcement.getId())
+                    .scrapId(scrapId)
+                    .dDay(DateUtil.convert(announcement.getDeadline()))
+                    .companyImage(announcement.getCompany().getCompanyImage())
+                    .title(announcement.getTitle())
+                    .workingPeriod(announcement.getWorkingPeriod())
+                    .isScrapped(isScrapped)
+                    .build();
+        }
+    }
+    public static SearchResultResponse of(List<SearchAnnouncementResponse> announcements) {
+        return new SearchResultResponse(announcements);
+    }
+
 }

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -9,7 +9,8 @@ public enum SuccessMessage {
 
     // Search (탐색 화면)
     SUCCESS_GET_MOST_VIEWED_ANNOUNCEMENTS(200, "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다"),
-    SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS(200, "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다");
+    SUCCESS_GET_MOST_SCRAPPED_ANNOUNCEMENTS(200, "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다"),
+    SUCCESS_GET_SEARCH_ANNOUNCEMENTS(200, "검색에 성공했습니다");
 
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepository.java
@@ -1,4 +1,4 @@
-package org.terning.terningserver.repository.InternshipAnnouncement;
+package org.terning.terningserver.repository.internship_announcement;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.terning.terningserver.domain.InternshipAnnouncement;

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -1,10 +1,14 @@
-package org.terning.terningserver.repository.InternshipAnnouncement;
+package org.terning.terningserver.repository.internship_announcement;
 
 import org.terning.terningserver.domain.InternshipAnnouncement;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 public interface InternshipRepositoryCustom {
     List<InternshipAnnouncement> getMostViewedInternship();
+
     List<InternshipAnnouncement> getMostScrappedInternship();
+
+    List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -1,8 +1,8 @@
 package org.terning.terningserver.repository.internship_announcement;
 
+import org.springframework.data.domain.Pageable;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 public interface InternshipRepositoryCustom {

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -1,5 +1,6 @@
 package org.terning.terningserver.repository.internship_announcement;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 
@@ -10,5 +11,5 @@ public interface InternshipRepositoryCustom {
 
     List<InternshipAnnouncement> getMostScrappedInternship();
 
-    List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
+    Page<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -52,8 +52,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
         BooleanExpression isExpired = internshipAnnouncement.deadline.before(today);
 
         // 현재 시점보다 마감일이 지나지 않은 경우
-        BooleanExpression isNotExpired = internshipAnnouncement.deadline.after(today)
-                .or(internshipAnnouncement.deadline.eq(today));
+        BooleanExpression isNotExpired = internshipAnnouncement.deadline.goe(today);
 
         // 우선순위를 위한 Expression(지원된 공고는 정렬 우선순위 낮게 -> 밑에 깔리게)
         NumberTemplate<Integer> priority = Expressions.numberTemplate(
@@ -61,6 +60,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 "CASE WHEN {0} THEN 1 ELSE 2 END",
                 isNotExpired
         );
+
         return jpaQueryFactory
                 .selectFrom(internshipAnnouncement)
                 .leftJoin(internshipAnnouncement.scraps).fetchJoin()

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -1,13 +1,17 @@
 package org.terning.terningserver.repository.internship_announcement;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 
 import static org.terning.terningserver.domain.QInternshipAnnouncement.internshipAnnouncement;
 
-import java.awt.print.Pageable;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -42,9 +46,49 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
 
     @Override
     public List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
-        jpaQueryFactory
-                .selectFrom(InternshipAnnouncement)
-                .where
+        LocalDate today = LocalDate.now();
+
+        // 현재 시점보다 마감일이 지난 경우
+        BooleanExpression isExpired = internshipAnnouncement.deadline.before(today);
+
+        // 현재 시점보다 마감일이 지나지 않은 경우
+        BooleanExpression isNotExpired = internshipAnnouncement.deadline.after(today)
+                .or(internshipAnnouncement.deadline.eq(today));
+
+        // 우선순위를 위한 Expression(지원된 공고는 정렬 우선순위 낮게 -> 밑에 깔리게)
+        NumberTemplate<Integer> priority = Expressions.numberTemplate(
+                Integer.class,
+                "CASE WHEN {0} THEN 1 ELSE 2 END",
+                isNotExpired
+        );
+        return jpaQueryFactory
+                .selectFrom(internshipAnnouncement)
+                .leftJoin(internshipAnnouncement.scraps).fetchJoin()
+                .orderBy(priority.asc(), createOrderSpecifier(sortBy))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+    private OrderSpecifier createOrderSpecifier(String sortBy) {
+        return switch (sortBy) {
+            case "mostViewed" -> new OrderSpecifier<>(Order.DESC, internshipAnnouncement.viewCount);
+            case "shortestDuration" -> new OrderSpecifier<>(Order.ASC, getWorkingPeriodAsNumber());
+            case "longestDuration" -> new OrderSpecifier<>(Order.DESC, getWorkingPeriodAsNumber());
+            case "mostScrapped" -> new OrderSpecifier<>(Order.DESC, internshipAnnouncement.scrapCount);
+            default -> new OrderSpecifier<>(Order.ASC, internshipAnnouncement.deadline);
+        };
+    }
+
+    /**
+     * String 타입의 workingPeriod를 숫자로 정렬하게 하기 위한 메서드
+     * @return
+     */
+    private NumberTemplate<Integer> getWorkingPeriodAsNumber() {
+        return Expressions.numberTemplate(
+                Integer.class,
+                "CAST(SUBSTRING({0}, 1, LENGTH({0}) - 2) AS INTEGER)",
+                internshipAnnouncement.workingPeriod
+        );
     }
 
     //지원 마감일이 지나지 않은 공고

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -1,13 +1,13 @@
-package org.terning.terningserver.repository.InternshipAnnouncement;
+package org.terning.terningserver.repository.internship_announcement;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 
 import static org.terning.terningserver.domain.QInternshipAnnouncement.internshipAnnouncement;
 
+import java.awt.print.Pageable;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -38,6 +38,13 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 ) //지원 마감된 공고 및 30일 보다 오래된 공고 제외
                 .orderBy(internshipAnnouncement.scrapCount.desc(), internshipAnnouncement.createdAt.desc())
                 .fetch();
+    }
+
+    @Override
+    public List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
+        jpaQueryFactory
+                .selectFrom(InternshipAnnouncement)
+                .where
     }
 
     //지원 마감일이 지나지 않은 공고

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -9,8 +9,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.enums.Grade;
+import org.terning.terningserver.domain.enums.WorkingPeriod;
 
 import static org.terning.terningserver.domain.QInternshipAnnouncement.internshipAnnouncement;
+import static org.terning.terningserver.domain.QUser.user;
+
 
 import java.time.LocalDate;
 import java.util.List;
@@ -48,9 +52,6 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     public List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
         LocalDate today = LocalDate.now();
 
-        // 현재 시점보다 마감일이 지난 경우
-        BooleanExpression isExpired = internshipAnnouncement.deadline.before(today);
-
         // 현재 시점보다 마감일이 지나지 않은 경우
         BooleanExpression isNotExpired = internshipAnnouncement.deadline.goe(today);
 
@@ -71,16 +72,16 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     }
     private OrderSpecifier createOrderSpecifier(String sortBy) {
         return switch (sortBy) {
-            case "mostViewed" -> new OrderSpecifier<>(Order.DESC, internshipAnnouncement.viewCount);
-            case "shortestDuration" -> new OrderSpecifier<>(Order.ASC, getWorkingPeriodAsNumber());
-            case "longestDuration" -> new OrderSpecifier<>(Order.DESC, getWorkingPeriodAsNumber());
-            case "mostScrapped" -> new OrderSpecifier<>(Order.DESC, internshipAnnouncement.scrapCount);
-            default -> new OrderSpecifier<>(Order.ASC, internshipAnnouncement.deadline);
+            case "mostViewed" -> internshipAnnouncement.viewCount.desc();
+            case "shortestDuration" -> getWorkingPeriodAsNumber().asc();
+            case "longestDuration" -> getWorkingPeriodAsNumber().desc();
+            case "mostScrapped" -> internshipAnnouncement.scrapCount.desc();
+            default -> internshipAnnouncement.deadline.asc();
         };
     }
 
     /**
-     * String 타입의 workingPeriod를 숫자로 정렬하게 하기 위한 메서드
+     * String 타입의 workingPeriod를 숫자로 정렬하게 하기 위한 메서드ㅜ₩       ₩₩₩₩₩₩
      * @return
      */
     private NumberTemplate<Integer> getWorkingPeriodAsNumber() {

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -78,7 +78,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count =jpaQueryFactory
+        Long count = jpaQueryFactory
                 .select(internshipAnnouncement.count())
                 .from(internshipAnnouncement)
                 .leftJoin(internshipAnnouncement.scraps)

--- a/src/main/java/org/terning/terningserver/repository/scarp/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scarp/ScrapRepository.java
@@ -1,0 +1,12 @@
+package org.terning.terningserver.repository.scarp;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapRepositoryCustom {
+    Boolean existsByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
+}

--- a/src/main/java/org/terning/terningserver/repository/scarp/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/scarp/ScrapRepositoryCustom.java
@@ -1,0 +1,12 @@
+package org.terning.terningserver.repository.scarp;
+
+import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
+
+import java.util.List;
+
+public interface ScrapRepositoryCustom {
+
+    List<Scrap> findAllByInternshipAndUserId(List<InternshipAnnouncement> internshipAnnouncements, Long userId);
+
+}

--- a/src/main/java/org/terning/terningserver/repository/scarp/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/scarp/ScrapRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.terning.terningserver.repository.scarp;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
+
+import java.util.List;
+import static org.terning.terningserver.domain.QScrap.scrap;
+
+
+@RequiredArgsConstructor
+public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Scrap> findAllByInternshipAndUserId(List<InternshipAnnouncement> internshipAnnouncements, Long userId) {
+        return jpaQueryFactory
+                .selectFrom(scrap)
+                .where(scrap.internshipAnnouncement.in(internshipAnnouncements), scrap.user.id.eq(userId))
+                .fetch();
+    }
+}

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -20,6 +20,6 @@ public class ScrapServiceImpl implements ScrapService {
         LocalDate today = LocalDate.now();
         return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, today).stream()
                 .map(TodayScrapResponseDto::of)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -2,6 +2,7 @@ package org.terning.terningserver.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,44 +20,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class SearchService {
 
-    private final InternshipRepository internshipRepository;
-    private final ScrapRepository scrapRepository;
+public interface SearchService {
 
-    public PopularAnnouncementListResponse getMostViewedAnnouncements() {
-        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostViewedInternship();
-        return PopularAnnouncementListResponse.of(mostViewedInternships);
-    }
+    PopularAnnouncementListResponse getMostViewedAnnouncements();
 
-    public PopularAnnouncementListResponse getMostScrappedAnnouncements() {
-        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostScrappedInternship();
-        return PopularAnnouncementListResponse.of(mostViewedInternships);
-    }
+    PopularAnnouncementListResponse getMostScrappedAnnouncements();
 
-    public SearchResultResponse searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
-        List<InternshipAnnouncement> announcements = internshipRepository.searchInternshipAnnouncement(keyword, sortBy, pageable);
-
-        List<SearchResultResponse.SearchAnnouncementResponse> searchAnnouncementResponses = new ArrayList<>();
-
-        List<Scrap> scraps = scrapRepository.findAllByInternshipAndUserId(announcements, 1L);
-
-        //스크랩 정보를 매핑 (인턴 공고 ID -> 스크랩 ID)
-        Map<Long, Long> scrapMap = scraps.stream()
-                .collect(Collectors.toMap(
-                        scrap -> scrap.getInternshipAnnouncement().getId(),
-                        Scrap::getId
-                ));
-
-
-        return new SearchResultResponse(
-                announcements.stream()
-                        .map(a -> SearchResultResponse.SearchAnnouncementResponse.from(a, scrapMap.get(a.getId())))
-                        .collect(Collectors.toList())
-        );
-    }
+    SearchResultResponse searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 
 }

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -9,9 +9,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.domain.Scrap;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
+import org.terning.terningserver.dto.search.response.SearchResultResponse;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
+import org.terning.terningserver.repository.scarp.ScrapRepository;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +25,7 @@ import java.util.List;
 public class SearchService {
 
     private final InternshipRepository internshipRepository;
+    private final ScrapRepository scrapRepository;
 
     public PopularAnnouncementListResponse getMostViewedAnnouncements() {
         List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostViewedInternship();
@@ -30,9 +37,26 @@ public class SearchService {
         return PopularAnnouncementListResponse.of(mostViewedInternships);
     }
 
-    public List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
+    public SearchResultResponse searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
         List<InternshipAnnouncement> announcements = internshipRepository.searchInternshipAnnouncement(keyword, sortBy, pageable);
-        announcements.stream().map(announcement ->
+
+        List<SearchResultResponse.SearchAnnouncementResponse> searchAnnouncementResponses = new ArrayList<>();
+
+        List<Scrap> scraps = scrapRepository.findAllByInternshipAndUserId(announcements, 1L);
+
+        //스크랩 정보를 매핑 (인턴 공고 ID -> 스크랩 ID)
+        Map<Long, Long> scrapMap = scraps.stream()
+                .collect(Collectors.toMap(
+                        scrap -> scrap.getInternshipAnnouncement().getId(),
+                        Scrap::getId
+                ));
+
+
+        return new SearchResultResponse(
+                announcements.stream()
+                        .map(a -> SearchResultResponse.SearchAnnouncementResponse.from(a, scrapMap.get(a.getId())))
+                        .collect(Collectors.toList())
+        );
     }
 
 }

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -3,13 +3,13 @@ package org.terning.terningserver.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 @Service

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -2,14 +2,14 @@ package org.terning.terningserver.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
-import org.terning.terningserver.repository.InternshipAnnouncement.InternshipRepository;
-import org.terning.terningserver.util.DateUtil;
+import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 
-import java.time.LocalDate;
+import java.awt.print.Pageable;
 import java.util.List;
 
 @Service
@@ -27,6 +27,10 @@ public class SearchService {
     public PopularAnnouncementListResponse getMostScrappedAnnouncements() {
         List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostScrappedInternship();
         return PopularAnnouncementListResponse.of(mostViewedInternships);
+    }
+
+    public void searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
+        internshipRepository.searchInternshipAnnouncement(keyword, sortBy, pageable);
     }
 
 }

--- a/src/main/java/org/terning/terningserver/service/SearchService.java
+++ b/src/main/java/org/terning/terningserver/service/SearchService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
 import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 
@@ -29,8 +30,9 @@ public class SearchService {
         return PopularAnnouncementListResponse.of(mostViewedInternships);
     }
 
-    public void searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
-        internshipRepository.searchInternshipAnnouncement(keyword, sortBy, pageable);
+    public List<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
+        List<InternshipAnnouncement> announcements = internshipRepository.searchInternshipAnnouncement(keyword, sortBy, pageable);
+        announcements.stream().map(announcement ->
     }
 
 }

--- a/src/main/java/org/terning/terningserver/service/SearchServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/SearchServiceImpl.java
@@ -1,0 +1,63 @@
+package org.terning.terningserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
+import org.terning.terningserver.dto.search.response.PopularAnnouncementListResponse;
+import org.terning.terningserver.dto.search.response.SearchResultResponse;
+import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
+import org.terning.terningserver.repository.scarp.ScrapRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchServiceImpl implements SearchService {
+
+    private final InternshipRepository internshipRepository;
+    private final ScrapRepository scrapRepository;
+
+    @Override
+    public PopularAnnouncementListResponse getMostViewedAnnouncements() {
+        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostViewedInternship();
+        return PopularAnnouncementListResponse.of(mostViewedInternships);
+    }
+
+    @Override
+    public PopularAnnouncementListResponse getMostScrappedAnnouncements() {
+        List<InternshipAnnouncement> mostViewedInternships = internshipRepository.getMostScrappedInternship();
+        return PopularAnnouncementListResponse.of(mostViewedInternships);
+    }
+
+    @Override
+    public SearchResultResponse searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
+        Page<InternshipAnnouncement> pageAnnouncements = internshipRepository.searchInternshipAnnouncement(keyword, sortBy, pageable);
+
+        List<InternshipAnnouncement> announcements = pageAnnouncements.getContent();
+
+        List<SearchResultResponse.SearchAnnouncementResponse> searchAnnouncementResponses = new ArrayList<>();
+
+        List<Scrap> scraps = scrapRepository.findAllByInternshipAndUserId(announcements, 1L);
+
+        //스크랩 정보를 매핑 (인턴 공고 ID -> 스크랩 ID)
+        Map<Long, Long> scrapMap = scraps.stream()
+                .collect(Collectors.toMap(
+                        scrap -> scrap.getInternshipAnnouncement().getId(),
+                        Scrap::getId
+                ));
+
+        return new SearchResultResponse(
+                pageAnnouncements.getTotalPages(), pageAnnouncements.hasNext(), announcements.stream()
+                .map(a -> SearchResultResponse.SearchAnnouncementResponse.from(a, scrapMap.get(a.getId())))
+                .toList());
+    }
+
+}


### PR DESCRIPTION
# 📄 Work Description
- 검색 결과 화면 API

# ⚙️ ISSUE
- closed #31 


# 📷 Screenshot
 - Swagger 문서(API 테스트)
<img width="951" alt="스크린샷 2024-07-15 오후 6 16 14" src="https://github.com/user-attachments/assets/8d4d3355-d0f8-473a-9615-da374cf194a0">


# 💬 To Reviewers
1..collect(Collectors.toList()) > .toList()로 변경
- 저의 로직에서는 리스트가 수정될 필요가 없고, 반환되는 리스트의 수정이 불가능하므로 데이터의 안정성을 높이고자 다음과 같이 변경했습니다!
자세한 사항은 👉[블로그](https://velog.io/@cieroyou/Stream%EC%9D%84-List%EB%A1%9C-%EB%B3%80%ED%99%98%ED%95%98%EB%8A%94-%EB%8B%A4%EC%96%91%ED%95%9C-%EB%B0%A9%EB%B2%95%EA%B3%BC-%EC%B0%A8%EC%9D%B4Collectors.toList-vs-Stream.toList) 첨부해놓겠습니다.

2. 스크랩 여부를 알려주기 위한 쿼리
- 검색 화면의 경우, 인턴공고 리스트와 함께 각각의 인턴 공고를 사용자가 스크랩했다면 scrapId를 함께 Response Body에 넘겨줘야 하는데요!
인턴공고 하나하나마다 해당 인턴공고가 스크랩되었는지를 scrapRepository에서 조회하기에는 조회 쿼리가 너무 많이 나갈 것 같아서 최대한 쿼리를 줄여보고자 했습니다.

따라서 한 번에 인턴 공고에 대한 스크랩 정보를 가져오고, 해당 인턴공고 id와 스크랩 id를 매핑하는 코드를 통해서, 여러번의 검색쿼리를 한 쿼리로 줄일 수 있었습니다! (피드백 대환영🙇‍♀️)
https://github.com/teamterning/Terning-Server/blob/970aa43a5a92bb1e2a5281171b1f7cb791ffe014/src/main/java/org/terning/terningserver/service/SearchServiceImpl.java#L48-L55



# 🔗 Reference
