### PR TITLE
[✨feat/#40] 캘린더 > 월간 캘린더(리스트 뷰) 정보 조회 API

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/CalendarController.java
+++ b/src/main/java/org/terning/terningserver/controller/CalendarController.java
@@ -5,12 +5,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.CalendarSwagger;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
+import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.ScrapService;
 
 import java.util.List;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MONTHLY_SCRAPS;
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +30,17 @@ public class CalendarController implements CalendarSwagger {
         Long userId = getUserIdFromToken(token);
         List<MonthlyDefaultResponseDto> monthlyScraps = scrapService.getMonthlyScraps(userId, year, month);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_MONTHLY_SCRAPS, monthlyScraps));
+    }
+
+    @GetMapping("/calendar/monthly-list")
+    public ResponseEntity<SuccessResponse<List<MonthlyListResponseDto>>> getMonthlyScrapsAsList(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("year") int year,
+            @RequestParam("month") int month
+    ){
+        Long userId = getUserIdFromToken(token);
+        List<MonthlyListResponseDto> monthlyScraps = scrapService.getMonthlyScrapsAsList(userId, year, month);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST, monthlyScraps));
     }
 
     private Long getUserIdFromToken(String token){

--- a/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
+import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
 import java.time.Month;
@@ -14,6 +15,13 @@ public interface CalendarSwagger {
 
     @Operation(summary = "캘린더 > 월간 스크랩 공고 조회", description = "월간 스크랩 공고를 조회하는 API")
     ResponseEntity<SuccessResponse<List<MonthlyDefaultResponseDto>>> getMonthlyScraps(
+            String token,
+            int year,
+            int month
+    );
+
+    @Operation(summary = "캘린더 > 월간 스크랩 공고 조회 (리스트)", description = "월간 스크랩 공고를 리스트로 조회하는 API")
+    ResponseEntity<SuccessResponse<List<MonthlyListResponseDto>>> getMonthlyScrapsAsList(
             String token,
             int year,
             int month

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyListResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyListResponseDto.java
@@ -1,0 +1,47 @@
+package org.terning.terningserver.dto.calendar.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MonthlyListResponseDto(
+        String deadline,
+        List<ScrapDetail> scraps
+) {
+    @Builder
+    public static record ScrapDetail(
+            Long scrapId,
+            Long internshipAnnouncementId,
+            String title,
+            String dDay,
+            String workingPeriod,
+            String color,
+            String companyImage,
+            int startYear,
+            int startMonth
+    ){
+        public static ScrapDetail of(Long scrapId, Long internshipAnnouncementId, String title,
+                                     String dDay, String workingPeriod, String color,
+                                     String companyImage, int startYear, int startMonth){
+            return ScrapDetail.builder()
+                    .scrapId(scrapId)
+                    .internshipAnnouncementId(internshipAnnouncementId)
+                    .title(title)
+                    .dDay(dDay)
+                    .workingPeriod(workingPeriod)
+                    .color(color)
+                    .companyImage(companyImage)
+                    .startYear(startYear)
+                    .startMonth(startMonth)
+                    .build();
+        }
+    }
+
+    public static MonthlyListResponseDto of(String deadline, List<ScrapDetail> scraps){
+        return MonthlyListResponseDto.builder()
+                .deadline(deadline)
+                .scraps(scraps)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -18,7 +18,8 @@ public enum SuccessMessage {
     SUCCESS_GET_INTERNSHIP_DETAIL(200, "공고 상세 정보 불러오기에 성공했습니다"),
 
     // Calendar (캘린더 화면)
-    SUCCESS_GET_MONTHLY_SCRAPS(200, "캘린더 > (월간) 스크랩 된 공고 정보 불러오기를 성공했습니다");
+    SUCCESS_GET_MONTHLY_SCRAPS(200, "캘린더 > (월간) 스크랩 된 공고 정보 불러오기를 성공했습니다"),
+    SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST(200, "캘린더 > (월간) 스크랩 된 공고 정보 (리스트) 불러오기를 성공했습니다");
     ;
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/service/ScrapService.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapService.java
@@ -1,6 +1,7 @@
 package org.terning.terningserver.service;
 
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
+import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.List;
 public interface ScrapService {
     List<TodayScrapResponseDto> getTodayScrap(Long userId);
     List<MonthlyDefaultResponseDto> getMonthlyScraps(Long userId, int year, int month);
+    List<MonthlyListResponseDto> getMonthlyScrapsAsList(Long userId, int year, int month);
 }


### PR DESCRIPTION
# 📄 Work Description
### 캘린더 > 월간 캘린더(리스트 뷰) 정보 조회 API
- 조회하고자 하는 연도와 월을 입력하면 해당하는 년/월의 스크랩한 공고를 일별로 보여주는 월간 캘린더(리스트 뷰) 정보 조회 API


# ⚙️ ISSUE
- closed #40 


# 📷 Screenshot
 - Swagger(200 성공)
<img width="1425" alt="image" src="https://github.com/user-attachments/assets/052b8e8e-973a-4327-81b5-9fa1a28035f7">
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/995172ff-cf44-4ccc-9442-fae0d9a8b4db">
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/df6b17eb-22df-4c1b-8892-0d2827b897a8">
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/bdaba5c9-930d-4a59-b146-400333bb6684">

# 💬 To Reviewers

feat/#36 캘린더 > 월간 캘린더(기본 뷰) 정보 조회 API와 동일한 로직에 응답값만 달라져서 크게 변동사항은 없습니다..!


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
