### PR TITLE
[✨feat/#42] 캘린더 > 일간 캘린더(리스트 뷰) 정보 조회 API

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/CalendarController.java
+++ b/src/main/java/org/terning/terningserver/controller/CalendarController.java
@@ -4,15 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.CalendarSwagger;
+import org.terning.terningserver.dto.calendar.response.DailyScrapResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.ScrapService;
 
+import java.time.LocalDate;
 import java.util.List;
 
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MONTHLY_SCRAPS;
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST;
+import static org.terning.terningserver.exception.enums.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,6 +44,16 @@ public class CalendarController implements CalendarSwagger {
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST, monthlyScraps));
     }
 
+    @GetMapping("/calendar/daily")
+    public ResponseEntity<SuccessResponse<List<DailyScrapResponseDto>>> getDailyScraps(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("date") String date
+    ){
+        Long userId = getUserIdFromToken(token);
+        LocalDate localDate = LocalDate.parse(date);
+        List<DailyScrapResponseDto> dailyScraps = scrapService.getDailyScraps(userId, localDate);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_DAILY_SCRAPS, dailyScraps));
+    }
     private Long getUserIdFromToken(String token){
         //실제 토큰에서 userId를 받아오는 로직 구현
         return 1L;  //임시로 사용자 ID 1로 반환

--- a/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
@@ -3,11 +3,12 @@ package org.terning.terningserver.controller.swagger;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.terning.terningserver.dto.calendar.response.DailyScrapResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
-import java.time.Month;
 import java.util.List;
 
 @Tag(name = "Calendar", description = "캘린더 관련 API")
@@ -25,5 +26,11 @@ public interface CalendarSwagger {
             String token,
             int year,
             int month
+    );
+
+    @Operation(summary = "캘린더 > 일간 스크랩 공고 조회 (리스트)", description = "일간 스크랩 공고를 리스트로 조회하는 API")
+    ResponseEntity<SuccessResponse<List<DailyScrapResponseDto>>> getDailyScraps(
+            String token,
+            String date
     );
 }

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/DailyScrapResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/DailyScrapResponseDto.java
@@ -1,0 +1,32 @@
+package org.terning.terningserver.dto.calendar.response;
+
+import lombok.Builder;
+import org.terning.terningserver.domain.Scrap;
+import org.terning.terningserver.util.DateUtil;
+
+@Builder
+public record DailyScrapResponseDto(
+        Long scrapId,
+        Long internshipAnnouncementId,
+        String title,
+        String dDay,
+        String workingPeriod,
+        String color,
+        String companyImage,
+        int startYear,
+        int startMonth
+) {
+    public static DailyScrapResponseDto of(final Scrap scrap){
+        return DailyScrapResponseDto.builder()
+                .scrapId(scrap.getId())
+                .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
+                .title(scrap.getInternshipAnnouncement().getTitle())
+                .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
+                .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
+                .color(scrap.getColor().getColorValue())
+                .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
+                .startYear(scrap.getInternshipAnnouncement().getStartYear())
+                .startMonth(scrap.getInternshipAnnouncement().getStartMonth())
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyDefaultResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyDefaultResponseDto.java
@@ -16,7 +16,7 @@ public record MonthlyDefaultResponseDto(
             String title,
             String color
     ){
-        public static ScrapDetail of(Long scrapId, String title, String color){
+        public static ScrapDetail of(final Long scrapId, final String title, final String color){
             return ScrapDetail.builder()
                     .scrapId(scrapId)
                     .title(title)

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyListResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyListResponseDto.java
@@ -21,9 +21,9 @@ public record MonthlyListResponseDto(
             int startYear,
             int startMonth
     ){
-        public static ScrapDetail of(Long scrapId, Long internshipAnnouncementId, String title,
-                                     String dDay, String workingPeriod, String color,
-                                     String companyImage, int startYear, int startMonth){
+        public static ScrapDetail of(final Long scrapId, final Long internshipAnnouncementId, final String title,
+                                     final String dDay, final String workingPeriod, final String color,
+                                     final String companyImage, final int startYear, final int startMonth){
             return ScrapDetail.builder()
                     .scrapId(scrapId)
                     .internshipAnnouncementId(internshipAnnouncementId)

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -19,7 +19,8 @@ public enum SuccessMessage {
 
     // Calendar (캘린더 화면)
     SUCCESS_GET_MONTHLY_SCRAPS(200, "캘린더 > (월간) 스크랩 된 공고 정보 불러오기를 성공했습니다"),
-    SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST(200, "캘린더 > (월간) 스크랩 된 공고 정보 (리스트) 불러오기를 성공했습니다");
+    SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST(200, "캘린더 > (월간) 스크랩 된 공고 정보 (리스트) 불러오기를 성공했습니다"),
+    SUCCESS_GET_DAILY_SCRAPS(200, "캘린더 > (일간) 스크랩 된 공고 정보 불러오기를 성공했습니다"),
     ;
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/service/ScrapService.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapService.java
@@ -1,13 +1,16 @@
 package org.terning.terningserver.service;
 
+import org.terning.terningserver.dto.calendar.response.DailyScrapResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ScrapService {
     List<TodayScrapResponseDto> getTodayScrap(Long userId);
     List<MonthlyDefaultResponseDto> getMonthlyScraps(Long userId, int year, int month);
     List<MonthlyListResponseDto> getMonthlyScrapsAsList(Long userId, int year, int month);
+    List<DailyScrapResponseDto> getDailyScraps(Long userId, LocalDate date);
 }

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -3,6 +3,7 @@ package org.terning.terningserver.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.terning.terningserver.domain.Scrap;
+import org.terning.terningserver.dto.calendar.response.DailyScrapResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
@@ -87,4 +88,12 @@ public class ScrapServiceImpl implements ScrapService {
                 ))
                 .toList();
     }
+
+    @Override
+    public List<DailyScrapResponseDto> getDailyScraps(Long userId, LocalDate date){
+        return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, date).stream()
+                .map(DailyScrapResponseDto::of)
+                .toList();
+    }
 }
+


### PR DESCRIPTION
# 📄 Work Description
### 캘린더 > 일간 캘린더(리스트 뷰) 정보 조회 API
- 조회하고자 하는 연도와 월을 일이 저장된 date를 입력하면 해당하는 날짜의 스크랩한 공고를 보여주는 일간 캘린더 정보 조회 API

# ⚙️ ISSUE
- closed #42 


# 📷 Screenshot
 - Swagger(성공 200)
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/4b0c46f2-fa6a-466a-8be6-130cfacb4c12">
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/a2169847-f0be-4ddf-b646-67a53c77e9ba">
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/ac9f1774-2119-4d1f-9b1c-3c261c3229e8">


# 💬 To Reviewers
- 해당하는 날짜를 String 타입인 date로 받아왔습니다.
- String(문자열)로 받아오기 때문에 LocalDate.parse("yyyy-mm-dd") 내장 메서드를 이용해서 LocalDate 타입으로 변환해주는 작업을 추가했습니다..!
- 학습 때 참고한 문서를 따로 첨부하겠습니다:)



# 🔗 Reference
[Java - String을 파싱하여 LocalDate로 변환하는 방법](https://codechacha.com/ko/java-examples-how-to-convert-string-to-localdate/)
