### PR TITLE
[✨feat/#44] 마이페이지 > 프로필 정보 조회 API

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/UserProfileController.java
+++ b/src/main/java/org/terning/terningserver/controller/UserProfileController.java
@@ -1,0 +1,36 @@
+package org.terning.terningserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.terning.terningserver.controller.swagger.UserSwagger;
+import org.terning.terningserver.dto.user.response.ProfileResponseDto;
+import org.terning.terningserver.exception.dto.SuccessResponse;
+import org.terning.terningserver.service.UserService;
+
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_PROFILE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserProfileController implements UserSwagger {
+
+    private final UserService userService;
+
+    @GetMapping("/mypage/profile")
+    public ResponseEntity<SuccessResponse<ProfileResponseDto>> getProfile(
+            @RequestHeader("Authorization") String token
+    ){
+        Long userId = getUserIdFromToken(token);
+        ProfileResponseDto profile = userService.getProfile(userId);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_PROFILE, profile));
+    }
+
+    private Long getUserIdFromToken(String token){
+        //실제 토큰에서 userId를 가져오는 로직 구현
+        return 1L; //임시로 사용자 ID 1로 반환
+    }
+}

--- a/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/CalendarSwagger.java
@@ -7,7 +7,6 @@ import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
-import java.time.Month;
 import java.util.List;
 
 @Tag(name = "Calendar", description = "캘린더 관련 API")

--- a/src/main/java/org/terning/terningserver/controller/swagger/UserSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/UserSwagger.java
@@ -1,0 +1,16 @@
+package org.terning.terningserver.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.terning.terningserver.dto.user.response.ProfileResponseDto;
+import org.terning.terningserver.exception.dto.SuccessResponse;
+
+@Tag(name = "Mypage", description = "마이페이지 관련 API")
+public interface UserSwagger {
+
+    @Operation(summary = "마이페이지 > 프로필 정보 불러오기", description = "마이페이지에서 프로필 정보를 불러오는 API")
+    ResponseEntity<SuccessResponse<ProfileResponseDto>> getProfile(
+        String token
+    );
+}

--- a/src/main/java/org/terning/terningserver/dto/user/response/ProfileResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/ProfileResponseDto.java
@@ -1,0 +1,17 @@
+package org.terning.terningserver.dto.user.response;
+
+import lombok.Builder;
+import org.terning.terningserver.domain.User;
+
+@Builder
+public record ProfileResponseDto(
+        String name,
+        String authType
+) {
+    public static ProfileResponseDto of(final User user){
+        return ProfileResponseDto.builder()
+                .name(user.getName())
+                .authType(user.getAuthType().name().toUpperCase())
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -20,8 +20,10 @@ public enum SuccessMessage {
 
     // Calendar (캘린더 화면)
     SUCCESS_GET_MONTHLY_SCRAPS(200, "캘린더 > (월간) 스크랩 된 공고 정보 불러오기를 성공했습니다"),
-    SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST(200, "캘린더 > (월간) 스크랩 된 공고 정보 (리스트) 불러오기를 성공했습니다");
+    SUCCESS_GET_MONTHLY_SCRAPS_AS_LIST(200, "캘린더 > (월간) 스크랩 된 공고 정보 (리스트) 불러오기를 성공했습니다"),
 
+    // Mypage (마이페이지 화면)
+    SUCCESS_GET_PROFILE(200, "마이페이지 > 프로필 정보 불러오기를 성공했습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/org/terning/terningserver/service/UserService.java
+++ b/src/main/java/org/terning/terningserver/service/UserService.java
@@ -1,0 +1,7 @@
+package org.terning.terningserver.service;
+
+import org.terning.terningserver.dto.user.response.ProfileResponseDto;
+
+public interface UserService {
+    ProfileResponseDto getProfile(Long userId);
+}

--- a/src/main/java/org/terning/terningserver/service/UserServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/UserServiceImpl.java
@@ -1,0 +1,24 @@
+package org.terning.terningserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.terning.terningserver.domain.User;
+import org.terning.terningserver.dto.user.response.ProfileResponseDto;
+import org.terning.terningserver.exception.CustomException;
+import org.terning.terningserver.exception.enums.ErrorMessage;
+import org.terning.terningserver.repository.user.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    public ProfileResponseDto getProfile(Long userId){
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION)
+        );
+        return ProfileResponseDto.of(user);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,7 +31,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
# 📄 Work Description
###  마이페이지 > 프로필 정보 조회 API
- 마이페이지에서 특정 유저의 프로필 정보를 조회하는 API입니다.

# ⚙️ ISSUE
- closed #44 


# 📷 Screenshot
 - Swagger(200 성공)
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/dfe064b1-6b88-470f-987d-8d2636355147">
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/44c8b09e-91d3-441b-8c76-f55075304d71">



# 💬 To Reviewers
- 우선, 소셜로그인 구현이 완료되지 않았기 때문에  userId == 1로 두고 테스트를 진행 한 후 정상적으로 조회되는 것을 확인하였습니다.
- 토큰을 통해 해당 유저를 특정한 후, 유저의 이름과 인증타입(카카오, 애플 중 하나)을 응답으로 주는 API입니다.

# 🔗 Reference

