### PR TITLE
[✨fix/#66] 캘린더 관련 로직 & 홈화면 > 맞춤공고 추가 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpFilterRequestDto.java
@@ -7,10 +7,10 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record SignUpFilterRequestDto(
-        @NonNull int grade,
-        @NonNull int workingPeriod,
-        @NonNull int startYear,
-        @NonNull int startMonth
+        int grade,
+        int workingPeriod,
+        int startYear,
+        int startMonth
 
 ) {
     public static SignUpFilterRequestDto of(int grade, int workingPeriod, int startYear, int startMonth) {

--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpRequestDto.java
@@ -9,7 +9,7 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public record SignUpRequestDto(
         @NonNull String name,
-        @NonNull int profileImage,
+        int profileImage,
         @NonNull AuthType authType
 ) {
 

--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
@@ -6,6 +6,7 @@ import org.terning.terningserver.util.DateUtil;
 
 @Builder
 public record HomeResponseDto(
+        Long scrapId,
         Long intershipAnnouncementId,
         String title,
         String dDay,
@@ -13,10 +14,11 @@ public record HomeResponseDto(
         String companyImage,
         boolean isScrapped
 ) {
-    public static HomeResponseDto of(final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped){
+    public static HomeResponseDto of(final Long scrapId, final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped){
         String dDay = DateUtil.convert(internshipAnnouncement.getDeadline()); // dDay 계산 로직 추가
 
         return HomeResponseDto.builder()
+                .scrapId(scrapId)
                 .intershipAnnouncementId(internshipAnnouncement.getId())
                 .title(internshipAnnouncement.getTitle())
                 .dDay(dDay)

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
@@ -6,6 +6,7 @@ import org.terning.terningserver.domain.Scrap;
 import java.util.List;
 
 public interface ScrapRepositoryCustom {
+    Long findScrapIdByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId);
 
     List<Scrap> findAllByInternshipAndUserId(List<InternshipAnnouncement> internshipAnnouncements, Long userId);
 

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
@@ -3,11 +3,16 @@ package org.terning.terningserver.repository.scrap;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.domain.Scrap;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ScrapRepositoryCustom {
     Long findScrapIdByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId);
 
     List<Scrap> findAllByInternshipAndUserId(List<InternshipAnnouncement> internshipAnnouncements, Long userId);
+
+    List<Scrap> findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(Long userId, LocalDate start, LocalDate end);
+
+    List<Scrap> findScrapsByUserIdAndDeadlineOrderByDeadline(Long userId, LocalDate deadline);
 
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.domain.Scrap;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.terning.terningserver.domain.QScrap.scrap;
@@ -31,5 +32,25 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
                 .where(scrap.internshipAnnouncement.id.eq(internshipAnnouncementId)
                         .and(scrap.user.id.eq(userId)))
                 .fetchOne();
+    }
+
+    @Override
+    public List<Scrap> findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(Long userId, LocalDate start, LocalDate end){
+        return jpaQueryFactory
+                .selectFrom(scrap)
+                .where(scrap.user.id.eq(userId)
+                        .and(scrap.internshipAnnouncement.deadline.between(start, end)))
+                .orderBy(scrap.internshipAnnouncement.deadline.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<Scrap> findScrapsByUserIdAndDeadlineOrderByDeadline(Long userId, LocalDate deadline){
+        return jpaQueryFactory
+                .selectFrom(scrap)
+                .where(scrap.user.id.eq(userId)
+                        .and(scrap.internshipAnnouncement.deadline.eq(deadline)))
+                .orderBy(scrap.internshipAnnouncement.deadline.asc())
+                .fetch();
     }
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
@@ -22,4 +22,14 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
                 .where(scrap.internshipAnnouncement.in(internshipAnnouncements), scrap.user.id.eq(userId))
                 .fetch();
     }
+
+    @Override
+    public Long findScrapIdByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId) {
+        return jpaQueryFactory
+                .select(scrap.id)
+                .from(scrap)
+                .where(scrap.internshipAnnouncement.id.eq(internshipAnnouncementId)
+                        .and(scrap.user.id.eq(userId)))
+                .fetchOne();
+    }
 }

--- a/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
@@ -3,6 +3,7 @@ package org.terning.terningserver.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.dto.user.response.HomeResponseDto;
 import org.terning.terningserver.exception.CustomException;
@@ -32,8 +33,9 @@ public class HomeServiceImpl implements HomeService{
         return announcements.stream()
                 .map(announcement -> {
                     boolean isScrapped = scrapRepository.existsByInternshipAnnouncementIdAndUserId(announcement.getId(), userId);
-                    return HomeResponseDto.of(announcement, isScrapped);
+                    Long scrapId = isScrapped ? scrapRepository.findScrapIdByInternshipAnnouncementIdAndUserId(announcement.getId(), userId) : null;
+                    return HomeResponseDto.of(scrapId, announcement, isScrapped);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -52,13 +52,14 @@ public class ScrapServiceImpl implements ScrapService {
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.plusMonths(1).minusDays(1);
 
-        List<Scrap> scraps = scrapRepository.findByUserIdAndInternshipAnnouncement_DeadlineBetween(userId, start, end);
+        List<Scrap> scraps = scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(userId, start, end);
 
         //deadline 별로 그룹화
         Map<LocalDate, List<Scrap>> scrapsByDeadline = scraps.stream()
                 .collect(Collectors.groupingBy(s -> s.getInternshipAnnouncement().getDeadline()));
 
         return scrapsByDeadline.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> MonthlyDefaultResponseDto.of(
                         entry.getKey().toString(),
                         entry.getValue().stream()
@@ -79,13 +80,14 @@ public class ScrapServiceImpl implements ScrapService {
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.plusMonths(1).minusDays(1);
 
-        List<Scrap> scraps = scrapRepository.findByUserIdAndInternshipAnnouncement_DeadlineBetween(userId, start, end);
+        List<Scrap> scraps = scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(userId, start, end);
 
         //deadline 별로 그룹화
         Map<LocalDate, List<Scrap>> scrapsByDeadline = scraps.stream()
                 .collect(Collectors.groupingBy(s -> s.getInternshipAnnouncement().getDeadline()));
 
         return scrapsByDeadline.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> MonthlyListResponseDto.of(
                         entry.getKey().toString(),
                         entry.getValue().stream()
@@ -107,7 +109,7 @@ public class ScrapServiceImpl implements ScrapService {
   
     @Override
     public List<DailyScrapResponseDto> getDailyScraps(Long userId, LocalDate date) {
-        return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, date).stream()
+        return scrapRepository.findScrapsByUserIdAndDeadlineOrderByDeadline(userId, date).stream()
                 .map(DailyScrapResponseDto::of)
                 .toList();
     }


### PR DESCRIPTION
# 📄 Work Description
- [✨fix/#66] 캘린더 관련 로직 & 홈화면 > 맞춤공고 추가 수정
- 캘린더 > 정보를 조회할 때, deadline이 이른 순으로 정렬되도록 로직 수정
- 홈화면 > 나에게 딱 맞춘 대학생 인턴공고 API에서 스크랩 추가&취소를 위한 scrapId를 추가로 반환하도록 수정

# ⚙️ ISSUE
- closed #66 


# 📷 Screenshot
 - Swagger(200 성공) 캘린더 정보 deadline 이른 순으로 정렬
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/cc62bb86-26cc-46c4-aea8-2b9c54ee3445">
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/664f3dc1-a02f-43d0-90a3-66bb5f67f3b5">

- 홈화면 > 나에게 딱 맞는 대학생 인턴 공고 - 스크랩ID 추가 반환하도록 수정
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/19c5ee24-cad5-4e83-9b9b-5440ba09e638">

# 💬 To Reviewers
리뷰어들에게 하고 싶은 말


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
