### PR TITLE
[🔨fix/#82]: 필터링 재설정 dto 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/domain/enums/Color.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Color.java
@@ -10,7 +10,7 @@ public enum Color {
 
     RED(0, "ED4E54"),
     ORANGE1(1, "EE7647"),
-    ORANGE2(2, "5397F3"),
+    ORANGE2(2, "F3A649"),
     YELLOW(3, "F5E660"),
     GREEN1(4, "C4E953"),
     GREEN2(5, "84D558"),

--- a/src/main/java/org/terning/terningserver/dto/filter/request/UserFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/request/UserFilterRequestDto.java
@@ -1,8 +1,6 @@
 package org.terning.terningserver.dto.filter.request;
 
 public record UserFilterRequestDto(
-
-        Long userId,
         int grade,
         int workingPeriod,
         int startYear,


### PR DESCRIPTION
# 📄 Work Description
- UserFilterRequestDto에서 userId 필드 삭제

# ⚙️ ISSUE
- closed #82 


# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
- 필터링 재설정 API에서 request header로 ATK를 받고 있기 때문에, UserFilterRequestDto에서 userId 필드를 삭제했습니다.
```java
public record UserFilterRequestDto(
        int grade,
        int workingPeriod,
        int startYear,
        int startMonth
) {
}
```


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
