### PR TITLE
[🔥!hotfix/#84] 홈 > 나에게 딱맞는 인턴 공고 조회 응답 데이터 변경

### DIFF
--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
@@ -10,19 +10,25 @@ public record HomeResponseDto(
         Long intershipAnnouncementId,
         String title,
         String dDay,
+        String deadline,
         String workingPeriod,
+        String startYearMonth,
         String companyImage,
         boolean isScrapped
 ) {
     public static HomeResponseDto of(final Long scrapId, final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped){
         String dDay = DateUtil.convert(internshipAnnouncement.getDeadline()); // dDay 계산 로직 추가
+        String startYearMonth = internshipAnnouncement.getStartYear() + "년 " + internshipAnnouncement.getStartMonth() + "월";
+        String deadline = DateUtil.convertDeadline(internshipAnnouncement.getDeadline());
 
         return HomeResponseDto.builder()
                 .scrapId(scrapId)
                 .intershipAnnouncementId(internshipAnnouncement.getId())
                 .title(internshipAnnouncement.getTitle())
                 .dDay(dDay)
+                .deadline(deadline)
                 .workingPeriod(internshipAnnouncement.getWorkingPeriod())
+                .startYearMonth(startYearMonth)
                 .companyImage(internshipAnnouncement.getCompany().getCompanyImage())
                 .isScrapped(isScrapped)
                 .build();


### PR DESCRIPTION
# 📄 Work Description
- 홈 > 나에게 딱맞는 인턴 공고 조회 응답 데이터 변경
- deadline(yyyy년 mm월 dd일), startYearMonth(yyyy년 mm월)을 추가로 dto로 반환할 수 있도록 적용

# ⚙️ ISSUE
- closed #84 


# 📷 Screenshot
 - Swagger(성공 200)
<img width="1420" alt="image" src="https://github.com/user-attachments/assets/3ec57865-a1bc-4476-b993-989059a7e460">

