### PR TITLE
[🔨fix/#82]: 필터릴 재설정 로직 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/domain/Filter.java
+++ b/src/main/java/org/terning/terningserver/domain/Filter.java
@@ -33,10 +33,12 @@ public class Filter {
 
     private int startMonth; // 근무 시작 월
 
+
     public void updateFilter(Grade grade, WorkingPeriod workingPeriod, int startYear, int startMonth) {
         this.grade = grade;
         this.workingPeriod = workingPeriod;
         this.startYear = startYear;
         this.startMonth = startMonth;
     }
+
 }

--- a/src/main/java/org/terning/terningserver/domain/User.java
+++ b/src/main/java/org/terning/terningserver/domain/User.java
@@ -83,4 +83,5 @@ public class User extends BaseTimeEntity {
         this.authId = authId;
         this.refreshToken = user.getRefreshToken();
     }
+
 }

--- a/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
@@ -11,6 +11,7 @@ import org.terning.terningserver.domain.enums.WorkingPeriod;
 import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.CustomException;
+import org.terning.terningserver.repository.filter.FilterRepository;
 import org.terning.terningserver.repository.user.UserRepository;
 
 import static org.terning.terningserver.exception.enums.ErrorMessage.NOT_FOUND_USER_EXCEPTION;
@@ -21,6 +22,7 @@ import static org.terning.terningserver.exception.enums.ErrorMessage.NOT_FOUND_U
 public class FilterServiceImpl implements FilterService {
 
     private final UserRepository userRepository;
+    private final FilterRepository filterRepository;
 
     @Override
     public UserFilterResponseDto getUserFilter(Long userId) {
@@ -32,7 +34,6 @@ public class FilterServiceImpl implements FilterService {
     public void updateUserFilter(UserFilterRequestDto responseDto, Long userId) {
         User user = findUser(userId);
         Filter filter = user.getFilter();
-        System.out.println("filter = " + filter);
         if(filter != null){
             filter.updateFilter(
                     Grade.fromKey(responseDto.grade()),
@@ -40,6 +41,16 @@ public class FilterServiceImpl implements FilterService {
                     responseDto.startYear(),
                     responseDto.startMonth()
             );
+        } else {
+            Filter savedFilter = filterRepository.save(
+                    Filter.builder()
+                            .grade(Grade.fromKey(responseDto.grade()))
+                            .workingPeriod(WorkingPeriod.fromKey(responseDto.workingPeriod()))
+                            .startYear(responseDto.startYear())
+                            .startMonth(responseDto.startMonth())
+                            .build()
+            );
+            user.assignFilter(savedFilter);
         }
     }
 


### PR DESCRIPTION
# 📄 Work Description
- 필터링 설정 안 한 유저가 재설정시 오류나는  문제 해결


# ⚙️ ISSUE
- closed #82 


# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
- 회원가입시 필터링 단계를 안 거친 유저, 즉 filter가 null인 유저가 필터링 재설정을 요청할 시 오류가 나는 문제를 해결했습니다.
```
    public void updateUserFilter(UserFilterRequestDto responseDto, Long userId) {
        User user = findUser(userId);
        Filter filter = user.getFilter();
        if(filter != null){
            filter.updateFilter(
                    Grade.fromKey(responseDto.grade()),
                    WorkingPeriod.fromKey(responseDto.workingPeriod()),
                    responseDto.startYear(),
                    responseDto.startMonth()
            );
        } else {
            Filter savedFilter = filterRepository.save(
                    Filter.builder()
                            .grade(Grade.fromKey(responseDto.grade()))
                            .workingPeriod(WorkingPeriod.fromKey(responseDto.workingPeriod()))
                            .startYear(responseDto.startYear())
                            .startMonth(responseDto.startMonth())
                            .build()
            );
            user.assignFilter(savedFilter);
        }
    }
```

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
