### PR TITLE
[🔥 !hotfix/#91]: 사용자가 해당 공고를 이미 스크랩했을 경우 예외처리 로직 추가

### DIFF
--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -22,6 +22,9 @@ public enum ErrorMessage {
     // 사용자 필터링 정보 생성
     FAILED_SIGN_UP_FILTER(404, "회원가입 필터링 정보 생성에 실패하였습니다"),
 
+    //스크랩
+    EXISTS_SCRAP_ALREADY(400, "이미 스크랩했습니다."),
+
     // 로그 아웃
     FAILED_SIGN_OUT(404, "로그아웃에 실패하였습니다"),
     FAILED_REFRESH_TOKEN_RESET(400, "리프레쉬 토큰 초기화에 실패하였습니다"),

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -14,7 +14,6 @@ import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.exception.CustomException;
-import org.terning.terningserver.jwt.PrincipalHandler;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
@@ -117,6 +116,12 @@ public class ScrapServiceImpl implements ScrapService {
     @Override
     @Transactional
     public void createScrap(Long internshipAnnouncementId, CreateScrapRequestDto request, Long userId) {
+
+        //이미 스크랩 했을 경우 예외처리
+        if(scrapRepository.existsByInternshipAnnouncementIdAndUserId(internshipAnnouncementId, userId)) {
+            throw new CustomException(EXISTS_SCRAP_ALREADY);
+        }
+
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
 
         announcement.updateScrapCount(1);


### PR DESCRIPTION
# 📄 Work Description
- 사용자가 해당 공고를 이미 스크랩했을 경우 예외처리 로직 추가

# ⚙️ ISSUE
- closed #91 


# 📷 Screenshot
- postman 화면
<img width="600" alt="스크린샷 2024-07-19 오후 11 34 54" src="https://github.com/user-attachments/assets/1542fe80-064b-4494-b924-53b45993f9a4">


# 💬 To Reviewers
- 스크랩 추가 API에서, 사용자가 이미 해당 공고를 스크랩을 경우, 스크랩 성공처리가 되지 않도록 예외처리 로직을 추가했습니다.
```java
    @Override
    @Transactional
    public void createScrap(Long internshipAnnouncementId, CreateScrapRequestDto request, Long userId) {

        //이미 스크랩 했을 경우 예외처리
        if(scrapRepository.existsByInternshipAnnouncementIdAndUserId(internshipAnnouncementId, userId)) {
            throw new CustomException(EXISTS_SCRAP_ALREADY);
        }

        InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);

        announcement.updateScrapCount(1);

        scrapRepository.save(Scrap.create(
                findUser(userId),
                getInternshipAnnouncement(internshipAnnouncementId),
                findColor(request.color())
        ));
    }
```

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
