### PR TITLE
[♻️refactor/#97] [2차] 홈화면 > 딱 맞는 대학생 인턴 공고 : 데이터 형식 및 추가 변동사항 적용

### DIFF
--- a/src/main/java/org/terning/terningserver/TerningserverApplication.java
+++ b/src/main/java/org/terning/terningserver/TerningserverApplication.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class TerningserverApplication {
 
 	public static void main(String[] args) {
-		//run
 		SpringApplication.run(TerningserverApplication.class, args);
 	}
 

--- a/src/main/java/org/terning/terningserver/TerningserverApplication.java
+++ b/src/main/java/org/terning/terningserver/TerningserverApplication.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class TerningserverApplication {
 
 	public static void main(String[] args) {
+		//run
 		SpringApplication.run(TerningserverApplication.class, args);
 	}
 

--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.HomeSwagger;
+import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 import org.terning.terningserver.dto.user.response.HomeResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.exception.CustomException;
@@ -28,13 +29,13 @@ public class HomeController implements HomeSwagger {
     private final ScrapService scrapService;
 
     @GetMapping("/home")
-    public ResponseEntity<SuccessResponse<List<HomeResponseDto>>> getAnnouncements(
+    public ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             @AuthenticationPrincipal Long userId,
             @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy,
             @RequestParam("startYear") int startYear,
             @RequestParam("startMonth") int startMonth
     ){
-        List<HomeResponseDto> announcements = homeService.getAnnouncements(userId, sortBy, startYear, startMonth);
+        HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy, startYear, startMonth);
 
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
     }

--- a/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
@@ -1,13 +1,9 @@
 package org.terning.terningserver.controller.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.terning.terningserver.dto.user.response.HomeResponseDto;
+import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
@@ -17,7 +13,7 @@ import java.util.List;
 public interface HomeSwagger {
 
     @Operation(summary = "홈화면 > 나에게 딱맞는 인턴 공고 조회", description = "특정 사용자에 필터링 조건에 맞는 인턴 공고 정보를 조회하는 API")
-    ResponseEntity<SuccessResponse<List<HomeResponseDto>>> getAnnouncements(
+    ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             Long userId,
             String sortBy,
             int startYear,

--- a/src/main/java/org/terning/terningserver/domain/Scrap.java
+++ b/src/main/java/org/terning/terningserver/domain/Scrap.java
@@ -53,5 +53,8 @@ public class Scrap extends BaseTimeEntity {
     public void updateColor(Color color) {
         this.color = color;
     }
-    
+
+    public String getColorToHexValue(){
+        return this.color.getColorValue();
+    }
 }

--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeAnnouncementsResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeAnnouncementsResponseDto.java
@@ -1,0 +1,18 @@
+package org.terning.terningserver.dto.user.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record HomeAnnouncementsResponseDto(
+        int totalCount, // 필터링 된 공고 총 개수
+        List<HomeResponseDto> result
+) {
+    public static HomeAnnouncementsResponseDto of(final int totalCount, final List<HomeResponseDto> announcements){
+        return HomeAnnouncementsResponseDto.builder()
+                .totalCount(totalCount)
+                .result(announcements)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
@@ -6,32 +6,31 @@ import org.terning.terningserver.util.DateUtil;
 
 @Builder
 public record HomeResponseDto(
-        Long scrapId,
         Long intershipAnnouncementId,
-        String title,
-        String dDay,
-        String deadline,
-        String workingPeriod,
-        String startYearMonth,
         String companyImage,
-        boolean isScrapped
+        String dDay,
+        String title,
+        String workingPeriod,
+        boolean isScrapped,
+        String color,
+        String deadline,
+        String startYearMonth
 ) {
-    public static HomeResponseDto of(final Long scrapId, final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped){
+    public static HomeResponseDto of(final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped, final String color){
         String dDay = DateUtil.convert(internshipAnnouncement.getDeadline()); // dDay 계산 로직 추가
         String startYearMonth = internshipAnnouncement.getStartYear() + "년 " + internshipAnnouncement.getStartMonth() + "월";
         String deadline = DateUtil.convertDeadline(internshipAnnouncement.getDeadline());
 
         return HomeResponseDto.builder()
-                .scrapId(scrapId)
                 .intershipAnnouncementId(internshipAnnouncement.getId())
-                .title(internshipAnnouncement.getTitle())
-                .dDay(dDay)
-                .deadline(deadline)
-                .workingPeriod(internshipAnnouncement.getWorkingPeriod())
-                .startYearMonth(startYearMonth)
                 .companyImage(internshipAnnouncement.getCompany().getCompanyImage())
+                .dDay(dDay)
+                .title(internshipAnnouncement.getTitle())
+                .workingPeriod(internshipAnnouncement.getWorkingPeriod())
                 .isScrapped(isScrapped)
+                .color(color)
+                .deadline(deadline)
+                .startYearMonth(startYearMonth)
                 .build();
     }
-
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface ScrapRepositoryCustom {
 
     List<Scrap> findScrapsByUserIdAndDeadlineOrderByDeadline(Long userId, LocalDate deadline);
 
+    String findColorByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId);
+
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
@@ -53,4 +53,15 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
                 .orderBy(scrap.internshipAnnouncement.deadline.asc())
                 .fetch();
     }
+
+    @Override
+    public String findColorByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId){
+        Scrap foundScrap = jpaQueryFactory
+                .selectFrom(scrap)
+                .where(scrap.internshipAnnouncement.id.eq(internshipAnnouncementId)
+                        .and(scrap.user.id.eq(userId)))
+                .fetchOne();
+
+        return foundScrap != null ? foundScrap.getColorToHexValue() : null;
+    }
 }

--- a/src/main/java/org/terning/terningserver/service/HomeService.java
+++ b/src/main/java/org/terning/terningserver/service/HomeService.java
@@ -1,10 +1,8 @@
 package org.terning.terningserver.service;
 
-import org.terning.terningserver.dto.user.response.HomeResponseDto;
-
-import java.util.List;
+import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 
 public interface HomeService {
 
-    List<HomeResponseDto> getAnnouncements(Long userId, String sortBy, int startYear, int startMonth);
+    HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy, int startYear, int startMonth);
 }

--- a/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
@@ -2,6 +2,7 @@ package org.terning.terningserver.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
@@ -16,6 +17,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class HomeServiceImpl implements HomeService{
 
     private final InternshipRepository internshipRepository;

--- a/src/main/java/org/terning/terningserver/service/KakaoServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/KakaoServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.val;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.terning.terningserver.config.ValueConfig;
 import org.terning.terningserver.exception.CustomException;
@@ -25,6 +26,7 @@ public class KakaoServiceImpl implements KakaoService {
     private final ObjectMapper objectMapper;
 
     @Override
+    @Transactional(readOnly = true)
     public String getKakaoData(String authAccessToken) {
         try {
             val headers = new HttpHeaders();


### PR DESCRIPTION
# 📄 Work Description
- 기존에는 뷰가 유사하지만 데이터 형식을 다르게 전달된 부분들이 있어, 코드의 통일성과 유지보수성을 높이기 위해 전달되는 데이터의 형식을 최대한 통일하는 작업을 진행했습니다.
- 필터링 된 공고의 총 개수(`totalCount`)를 추가로 보내주도록 수정했습니다. (`HomeAnnouncementsResponseDto`)
- `startYear`, `startMonth` → `startYearMonth`로 변수 통합했습니다.
- 스크랩 추가 & 취소 & 색상 수정시 모두 기존 scrapId에서 `internshipAnnouncementId`로 통신하는 것으로 변경되었으므로 해당 API에서는 더 이상 scrapId가 아닌 `isScrapped`라는 필드로 스크랩 여부를 전달하도록 수정했습니다.
- `isScrapped`가 false(스크랩한 공고가 아닌 경우)인 경우, `color`도 null값을 출력하도록 구현하였습니다.
- Scrap의 Enum에 `getColorToHexValue()` 메서드를 추가하여 헥사값의 컬러를 직접 참조하여 가져올 수 있도록 추가하였습니다.

# ⚙️ ISSUE
- closed #97 


# 📷 Screenshot
### Swagger 200
- totalCount 출력 + scrapId 삭제 + isScrapped 추가 + color 추가(isScrapped가 false이면 null값 전달)
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/fdef53b0-4fbf-45df-833d-6bd4a45eb437">
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/e8a6ca74-2211-41cf-959b-d91d4b6046a9">

</br>

### Swagger 200 
- 전달되는 공고가 없을 경우 빈리스트와 totalCount = 0 반환
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/f4c2b431-def1-4145-862c-1d24f8636b51">


# 💬 To Reviewers
리뷰어들에게 하고 싶은 말
 

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
