### PR TITLE
[♻️ refactor] [2차] 홈화면 > 오늘 마감되는 관심 공고 & 캘린더(일간,월간) : 데이터 형식 및 추가 변동사항 적용

### DIFF
--- a/src/main/java/org/terning/terningserver/TerningserverApplication.java
+++ b/src/main/java/org/terning/terningserver/TerningserverApplication.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 public class TerningserverApplication {
 
-	public static void main(String[] args) { //run
+	public static void main(String[] args) {
 		SpringApplication.run(TerningserverApplication.class, args);
 	}
 

--- a/src/main/java/org/terning/terningserver/TerningserverApplication.java
+++ b/src/main/java/org/terning/terningserver/TerningserverApplication.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 public class TerningserverApplication {
 
-	public static void main(String[] args) {
+	public static void main(String[] args) { //run
 		SpringApplication.run(TerningserverApplication.class, args);
 	}
 

--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.HomeSwagger;
+import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 import org.terning.terningserver.dto.user.response.HomeResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.exception.CustomException;
@@ -28,13 +29,13 @@ public class HomeController implements HomeSwagger {
     private final ScrapService scrapService;
 
     @GetMapping("/home")
-    public ResponseEntity<SuccessResponse<List<HomeResponseDto>>> getAnnouncements(
+    public ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             @AuthenticationPrincipal Long userId,
             @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy,
             @RequestParam("startYear") int startYear,
             @RequestParam("startMonth") int startMonth
     ){
-        List<HomeResponseDto> announcements = homeService.getAnnouncements(userId, sortBy, startYear, startMonth);
+        HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy, startYear, startMonth);
 
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
     }

--- a/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
@@ -1,13 +1,9 @@
 package org.terning.terningserver.controller.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.terning.terningserver.dto.user.response.HomeResponseDto;
+import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
@@ -17,7 +13,7 @@ import java.util.List;
 public interface HomeSwagger {
 
     @Operation(summary = "홈화면 > 나에게 딱맞는 인턴 공고 조회", description = "특정 사용자에 필터링 조건에 맞는 인턴 공고 정보를 조회하는 API")
-    ResponseEntity<SuccessResponse<List<HomeResponseDto>>> getAnnouncements(
+    ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             Long userId,
             String sortBy,
             int startYear,

--- a/src/main/java/org/terning/terningserver/domain/Scrap.java
+++ b/src/main/java/org/terning/terningserver/domain/Scrap.java
@@ -53,5 +53,8 @@ public class Scrap extends BaseTimeEntity {
     public void updateColor(Color color) {
         this.color = color;
     }
-    
+
+    public String getColorToHexValue(){
+        return this.color.getColorValue();
+    }
 }

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/DailyScrapResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/DailyScrapResponseDto.java
@@ -6,27 +6,30 @@ import org.terning.terningserver.util.DateUtil;
 
 @Builder
 public record DailyScrapResponseDto(
-        Long scrapId,
         Long internshipAnnouncementId,
-        String title,
-        String dDay,
-        String workingPeriod,
-        String color,
         String companyImage,
-        int startYear,
-        int startMonth
+        String dDay,
+        String title,
+        String workingPeriod,
+        boolean isScrapped,
+        String color,
+        String deadline,
+        String startYearMonth
 ) {
     public static DailyScrapResponseDto of(final Scrap scrap){
+        String startYearMonth = scrap.getInternshipAnnouncement().getStartYear() + "년 " + scrap.getInternshipAnnouncement().getStartMonth() + "월";
+        String deadline = DateUtil.convertDeadline(scrap.getInternshipAnnouncement().getDeadline());
+
         return DailyScrapResponseDto.builder()
-                .scrapId(scrap.getId())
                 .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
-                .title(scrap.getInternshipAnnouncement().getTitle())
-                .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
-                .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
-                .color(scrap.getColor().getColorValue())
                 .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
-                .startYear(scrap.getInternshipAnnouncement().getStartYear())
-                .startMonth(scrap.getInternshipAnnouncement().getStartMonth())
+                .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
+                .title(scrap.getInternshipAnnouncement().getTitle())
+                .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
+                .isScrapped(true) // 스크랩된 경우에만 DTO 생성하므로 true
+                .color(scrap.getColorToHexValue())
+                .deadline(deadline)
+                .startYearMonth(startYearMonth)
                 .build();
     }
 }

--- a/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyListResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/calendar/response/MonthlyListResponseDto.java
@@ -7,41 +7,41 @@ import java.util.List;
 @Builder
 public record MonthlyListResponseDto(
         String deadline,
-        List<ScrapDetail> scraps
+        List<ScrapDetail> announcements
 ) {
     @Builder
     public static record ScrapDetail(
-            Long scrapId,
             Long internshipAnnouncementId,
-            String title,
-            String dDay,
-            String workingPeriod,
-            String color,
             String companyImage,
-            int startYear,
-            int startMonth
+            String dDay,
+            String title,
+            String workingPeriod,
+            boolean isScrapped,
+            String color,
+            String deadline,
+            String startYearMonth
     ){
-        public static ScrapDetail of(final Long scrapId, final Long internshipAnnouncementId, final String title,
-                                     final String dDay, final String workingPeriod, final String color,
-                                     final String companyImage, final int startYear, final int startMonth){
+        public static ScrapDetail of(final Long internshipAnnouncementId, final String companyImage, final String dDay,
+                                     final String title, final String workingPeriod, final boolean isScrapped,
+                                     final String color, final String deadline, final String startYearMonth){
             return ScrapDetail.builder()
-                    .scrapId(scrapId)
                     .internshipAnnouncementId(internshipAnnouncementId)
-                    .title(title)
-                    .dDay(dDay)
-                    .workingPeriod(workingPeriod)
-                    .color(color)
                     .companyImage(companyImage)
-                    .startYear(startYear)
-                    .startMonth(startMonth)
+                    .dDay(dDay)
+                    .title(title)
+                    .workingPeriod(workingPeriod)
+                    .isScrapped(isScrapped)
+                    .color(color)
+                    .deadline(deadline)
+                    .startYearMonth(startYearMonth)
                     .build();
         }
     }
 
-    public static MonthlyListResponseDto of(String deadline, List<ScrapDetail> scraps){
+    public static MonthlyListResponseDto of(String deadline, List<ScrapDetail> announcements){
         return MonthlyListResponseDto.builder()
                 .deadline(deadline)
-                .scraps(scraps)
+                .announcements(announcements)
                 .build();
     }
 }

--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeAnnouncementsResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeAnnouncementsResponseDto.java
@@ -1,0 +1,18 @@
+package org.terning.terningserver.dto.user.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record HomeAnnouncementsResponseDto(
+        int totalCount, // 필터링 된 공고 총 개수
+        List<HomeResponseDto> result
+) {
+    public static HomeAnnouncementsResponseDto of(final int totalCount, final List<HomeResponseDto> announcements){
+        return HomeAnnouncementsResponseDto.builder()
+                .totalCount(totalCount)
+                .result(announcements)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeResponseDto.java
@@ -6,32 +6,31 @@ import org.terning.terningserver.util.DateUtil;
 
 @Builder
 public record HomeResponseDto(
-        Long scrapId,
         Long intershipAnnouncementId,
-        String title,
-        String dDay,
-        String deadline,
-        String workingPeriod,
-        String startYearMonth,
         String companyImage,
-        boolean isScrapped
+        String dDay,
+        String title,
+        String workingPeriod,
+        boolean isScrapped,
+        String color,
+        String deadline,
+        String startYearMonth
 ) {
-    public static HomeResponseDto of(final Long scrapId, final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped){
+    public static HomeResponseDto of(final InternshipAnnouncement internshipAnnouncement, final boolean isScrapped, final String color){
         String dDay = DateUtil.convert(internshipAnnouncement.getDeadline()); // dDay 계산 로직 추가
         String startYearMonth = internshipAnnouncement.getStartYear() + "년 " + internshipAnnouncement.getStartMonth() + "월";
         String deadline = DateUtil.convertDeadline(internshipAnnouncement.getDeadline());
 
         return HomeResponseDto.builder()
-                .scrapId(scrapId)
                 .intershipAnnouncementId(internshipAnnouncement.getId())
-                .title(internshipAnnouncement.getTitle())
-                .dDay(dDay)
-                .deadline(deadline)
-                .workingPeriod(internshipAnnouncement.getWorkingPeriod())
-                .startYearMonth(startYearMonth)
                 .companyImage(internshipAnnouncement.getCompany().getCompanyImage())
+                .dDay(dDay)
+                .title(internshipAnnouncement.getTitle())
+                .workingPeriod(internshipAnnouncement.getWorkingPeriod())
                 .isScrapped(isScrapped)
+                .color(color)
+                .deadline(deadline)
+                .startYearMonth(startYearMonth)
                 .build();
     }
-
 }

--- a/src/main/java/org/terning/terningserver/dto/user/response/TodayScrapResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/TodayScrapResponseDto.java
@@ -6,29 +6,29 @@ import org.terning.terningserver.util.DateUtil;
 
 @Builder
 public record TodayScrapResponseDto(
-        Long scrapId,
         Long internshipAnnouncementId,
         String companyImage,
-        String title,
         String dDay,
-        String deadline,
+        String title,
         String workingPeriod,
-        String startYearMonth,
-        String color
+        boolean isScrapped,
+        String color,
+        String deadline,
+        String startYearMonth
 ) {
     public static TodayScrapResponseDto of(final Scrap scrap){
         String startYearMonth = scrap.getInternshipAnnouncement().getStartYear() + "년 " + scrap.getInternshipAnnouncement().getStartMonth() + "월";
 
         return TodayScrapResponseDto.builder()
-                .scrapId(scrap.getId())
                 .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
                 .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
-                .title(scrap.getInternshipAnnouncement().getTitle())
                 .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
+                .title(scrap.getInternshipAnnouncement().getTitle())
                 .deadline(DateUtil.convertDeadline(scrap.getInternshipAnnouncement().getDeadline()))
+                .isScrapped(true) // 스크랩된 항목이므로 항상 true
+                .color(scrap.getColorToHexValue())
                 .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
                 .startYearMonth(startYearMonth)
-                .color(scrap.getColor().getColorValue())
                 .build();
     }
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface ScrapRepositoryCustom {
 
     List<Scrap> findScrapsByUserIdAndDeadlineOrderByDeadline(Long userId, LocalDate deadline);
 
+    String findColorByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId);
+
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
@@ -53,4 +53,15 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
                 .orderBy(scrap.internshipAnnouncement.deadline.asc())
                 .fetch();
     }
+
+    @Override
+    public String findColorByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId){
+        Scrap foundScrap = jpaQueryFactory
+                .selectFrom(scrap)
+                .where(scrap.internshipAnnouncement.id.eq(internshipAnnouncementId)
+                        .and(scrap.user.id.eq(userId)))
+                .fetchOne();
+
+        return foundScrap != null ? foundScrap.getColorToHexValue() : null;
+    }
 }

--- a/src/main/java/org/terning/terningserver/service/HomeService.java
+++ b/src/main/java/org/terning/terningserver/service/HomeService.java
@@ -1,10 +1,8 @@
 package org.terning.terningserver.service;
 
-import org.terning.terningserver.dto.user.response.HomeResponseDto;
-
-import java.util.List;
+import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 
 public interface HomeService {
 
-    List<HomeResponseDto> getAnnouncements(Long userId, String sortBy, int startYear, int startMonth);
+    HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy, int startYear, int startMonth);
 }

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -91,21 +91,20 @@ public class ScrapServiceImpl implements ScrapService {
                         entry.getKey().toString(),
                         entry.getValue().stream()
                                 .map(s -> MonthlyListResponseDto.ScrapDetail.of(
-                                        s.getId(),
                                         s.getInternshipAnnouncement().getId(),
-                                        s.getInternshipAnnouncement().getTitle(),
-                                        DateUtil.convert(s.getInternshipAnnouncement().getDeadline()),
-                                        s.getInternshipAnnouncement().getWorkingPeriod(),
-                                        s.getColor().getColorValue(),
                                         s.getInternshipAnnouncement().getCompany().getCompanyImage(),
-                                        s.getInternshipAnnouncement().getStartYear(),
-                                        s.getInternshipAnnouncement().getStartMonth()
+                                        DateUtil.convert(s.getInternshipAnnouncement().getDeadline()),
+                                        s.getInternshipAnnouncement().getTitle(),
+                                        s.getInternshipAnnouncement().getWorkingPeriod(),
+                                        true, // 이미 스크랩된 경우이므로 true
+                                        s.getColorToHexValue(),
+                                        DateUtil.convertDeadline(s.getInternshipAnnouncement().getDeadline()),
+                                        s.getInternshipAnnouncement().getStartYear() + "년 " + s.getInternshipAnnouncement().getStartMonth() + "월"
                                 ))
                                 .toList()
                 ))
                 .toList();
     }
-  
     @Override
     public List<DailyScrapResponseDto> getDailyScraps(Long userId, LocalDate date) {
         return scrapRepository.findScrapsByUserIdAndDeadlineOrderByDeadline(userId, date).stream()


### PR DESCRIPTION
# 📄 Work Description
- 기존에는 뷰가 유사하지만 데이터 형식을 다르게 전달된 부분들이 있어, 코드의 통일성과 유지보수성을 높이기 위해 전달되는 `데이터의 형식을 통일`하는 작업을 진행했습니다.
- `startYear`, `startMonth` → `startYearMonth`로 변수 통합했습니다.
- 스크랩 추가 & 취소 & 색상 수정시 모두 기존 scrapId에서 `internshipAnnouncementId`로 통신하는 것으로 변경되었으므로 해당 API에서는 더 이상 scrapId가 아닌 `isScrapped`라는 필드로 스크랩 여부를 전달하도록 수정했습니다.
- `isScrapped`는 무조건 true를 전달합니다. (캘린더에는 스크랩한 공고만 보여주므로)
- Scrap의 Enum에 `getColorToHexValue()` 메서드를 이용해 헥사값의 컬러를 직접 참조하여 가져올 수 있도록 변경하였습니다.

# ⚙️ ISSUE
- closed #99 


# 📷 Screenshot

### Swagger 200

- 홈화면 > 오늘 마감되는 관심공고
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/a841fef2-9b1f-41df-a8a9-04a093a3a7f8">

### Swagger 200

- 캘린더 > 일간 캘린더
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/8a1d702f-84b2-4b68-b15e-1772862911e3">

### Swagger 200

- 캘린더 > 월간 캘린더 (리스트 뷰)
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/a4b44b44-b84b-43d0-93bb-9c278de22b78">
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/ca51c137-cd1b-41a5-b74e-ed13a1df6c46">



# 💬 To Reviewers
리뷰어들에게 하고 싶은 말


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
