### PR TITLE
[♻️ refactor/#106] 소셜 로그인 > 토큰 생성 메서드 리팩토링 및 파라미터 간소화 작업

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/AuthController.java
+++ b/src/main/java/org/terning/terningserver/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController implements AuthSwagger {
             @RequestBody SignUpRequestDto request
     ) {
 
-        SignUpResponseDto signUpResponseDto = authService.signUp(authId, request.name(), request.profileImage(), request.authType());
+        SignUpResponseDto signUpResponseDto = authService.signUp(authId, request);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_SIGN_UP, signUpResponseDto));
     }
 

--- a/src/main/java/org/terning/terningserver/domain/User.java
+++ b/src/main/java/org/terning/terningserver/domain/User.java
@@ -65,23 +65,7 @@ public class User extends BaseTimeEntity {
         }
     }
 
-    public void updateProfile(String name, Integer profileImage) {
-        if (name != null && !name.isEmpty()) {
-            this.name = name;
-        }
-        if (profileImage != null) {
-            this.profileImage = profileImage;
-        }
-    }
-
     public void assignFilter(Filter filter) {
         this.filter = filter;
     }
-
-    public void updateUser(AuthType authType, String authId, User user) {
-        this.authType = authType;
-        this.authId = authId;
-        this.refreshToken = user.getRefreshToken();
-    }
-
 }

--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpWithAuthIdRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpWithAuthIdRequestDto.java
@@ -1,0 +1,24 @@
+package org.terning.terningserver.dto.auth.request;
+
+import lombok.Builder;
+import lombok.NonNull;
+import org.terning.terningserver.domain.enums.AuthType;
+
+import static lombok.AccessLevel.*;
+
+@Builder(access = PRIVATE)
+public record SignUpWithAuthIdRequestDto(
+        @NonNull String authId,
+        @NonNull String name,
+        int profileImage,
+        @NonNull AuthType authType
+) {
+    public static SignUpWithAuthIdRequestDto of(String authId, String name, int profileImage, AuthType authType){
+        return SignUpWithAuthIdRequestDto.builder()
+                .authId(authId)
+                .name(name)
+                .profileImage(profileImage)
+                .authType(authType)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/service/AuthService.java
+++ b/src/main/java/org/terning/terningserver/service/AuthService.java
@@ -2,6 +2,8 @@ package org.terning.terningserver.service;
 
 import org.terning.terningserver.domain.enums.AuthType;
 import org.terning.terningserver.dto.auth.request.SignInRequestDto;
+import org.terning.terningserver.dto.auth.request.SignUpRequestDto;
+import org.terning.terningserver.dto.auth.request.SignUpWithAuthIdRequestDto;
 import org.terning.terningserver.dto.auth.response.AccessTokenGetResponseDto;
 import org.terning.terningserver.dto.auth.response.SignInResponseDto;
 import org.terning.terningserver.dto.auth.response.SignUpResponseDto;
@@ -10,7 +12,7 @@ public interface AuthService {
 
     SignInResponseDto signIn(String authAccessToken, SignInRequestDto request);
 
-    SignUpResponseDto signUp(String authId, String name, Integer profileImage, AuthType authType);
+    SignUpResponseDto signUp(String authId, SignUpRequestDto request);
 
     void signOut(long userId);
 

--- a/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
@@ -10,6 +10,8 @@ import org.terning.terningserver.config.ValueConfig;
 import org.terning.terningserver.domain.Token;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.dto.auth.request.SignInRequestDto;
+import org.terning.terningserver.dto.auth.request.SignUpRequestDto;
+import org.terning.terningserver.dto.auth.request.SignUpWithAuthIdRequestDto;
 import org.terning.terningserver.dto.auth.response.AccessTokenGetResponseDto;
 import org.terning.terningserver.dto.auth.response.SignInResponseDto;
 import org.terning.terningserver.domain.enums.AuthType;
@@ -58,19 +60,14 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Transactional
-    public SignUpResponseDto signUp(String authId, String name, Integer profileImage, AuthType authType) {
+    public SignUpResponseDto signUp(String authId, SignUpRequestDto request) {
+        SignUpWithAuthIdRequestDto requestDto = createSignUpRequestDto(authId, request);
 
-        User user = userRepository.save(User.builder()
-                .authId(authId)
-                .name(name)
-                .authType(authType)
-                .profileImage(profileImage)
-                .build());
+        User user = createUser(requestDto);
 
         Token token = getToken(user);
-        userRepository.save(user);
 
-        return SignUpResponseDto.of(token.getAccessToken(), token.getRefreshToken(), user.getId(), authType);
+        return createSignUpResponseDto(token, user);
     }
 
     @Override
@@ -102,27 +99,54 @@ public class AuthServiceImpl implements AuthService {
     }
 
     public Token getToken(User user) {
-        val token = generateToken(new UserAuthentication(user.getId(), null, null));
-        user.updateRefreshToken(token.getRefreshToken());
-        return token;
+        String accessToken = createAccessToken(new UserAuthentication(user.getId(), null, null));
+        String refreshToken = createRefreshToken(new UserAuthentication(user.getId(), null, null));
+
+        user.updateRefreshToken(refreshToken);
+
+        return Token.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private SignUpWithAuthIdRequestDto createSignUpRequestDto(String authId, SignUpRequestDto request) {
+        return SignUpWithAuthIdRequestDto.of(
+                authId,
+                request.name(),
+                request.profileImage(),
+                request.authType()
+        );
+    }
+
+    private User createUser(SignUpWithAuthIdRequestDto requestDto) {
+        User user = User.builder()
+                .authId(requestDto.authId())
+                .name(requestDto.name())
+                .authType(requestDto.authType())
+                .profileImage(requestDto.profileImage())
+                .build();
+        return userRepository.save(user);
+    }
+
+    private SignUpResponseDto createSignUpResponseDto(Token token, User user) {
+        return SignUpResponseDto.of(token.getAccessToken(), token.getRefreshToken(), user.getId(), user.getAuthType());
     }
 
     public Token getAccessToken(User user) {
-        val accessToken = generateAccessToken(new UserAuthentication(user.getId(), null, null));
-        return accessToken;
-    }
+        String accessToken = createAccessToken(new UserAuthentication(user.getId(), null, null));
 
-    private Token generateToken(Authentication authentication) {
         return Token.builder()
-                .accessToken(jwtTokenProvider.generateToken(authentication, valueConfig.getAccessTokenExpired()))
-                .refreshToken(jwtTokenProvider.generateToken(authentication, valueConfig.getRefreshTokenExpired()))
+                .accessToken(accessToken)
                 .build();
     }
 
-    private Token generateAccessToken(Authentication authentication) {
-        return Token.builder()
-                .accessToken(jwtTokenProvider.generateToken(authentication, valueConfig.getAccessTokenExpired()))
-                .build();
+    private String createAccessToken(Authentication authentication) {
+        return jwtTokenProvider.generateToken(authentication, valueConfig.getAccessTokenExpired());
+    }
+
+    private String createRefreshToken(Authentication authentication) {
+        return jwtTokenProvider.generateToken(authentication, valueConfig.getRefreshTokenExpired());
     }
 
     private User findUser(long id) {


### PR DESCRIPTION
# 📄 Work Description
- **`SignUpWithAuthIdRequestDto` 생성**: 회원가입 시 필요한 데이터를 담는 DTO(Data Transfer Object)를 새롭게 정의하였습니다.
- **기존 로직 리팩토링**: `AuthController`, `User`, `AuthServiceImpl` 클래스에서 기존에 사용하던 회원가입 로직을 `SignUpWithAuthIdRequestDto`를 활용하도록 변경하였습니다.
  - `AuthController`: `signUp` 메서드의 파라미터를 단순화하고, `authService.signUp` 호출 시 새로운 DTO를 사용하도록 수정하였습니다.
  - `User` 클래스: 사용하지 않는 메서드를 삭제하고, `updateUser` 메서드를 리팩토링하였습니다.
  - `AuthServiceImpl`: 회원가입 로직을 세부 메서드로 분리하여 코드 가독성을 높였습니다.
  - `Token` 생성 로직을 분리하여 재사용성을 향상시켰습니다.

# ⚙️ ISSUE
- closed #106 

# 📷 Screenshot
## Swagger 200
<img width="1250" alt="스크린샷 2024-08-29 오후 2 07 57" src="https://github.com/user-attachments/assets/994d1c8c-d4fe-4ebc-b4a3-accaf91f88b3">
<img width="1248" alt="스크린샷 2024-08-29 오후 2 08 55" src="https://github.com/user-attachments/assets/c1899ac0-e53c-4e7b-9d61-6b04c24901ce">


# 💬 To Reviewers
- 이번 리팩토링 작업으로 회원가입 로직이 보다 명확하고 유지보수하기 쉽게 변경되었습니다. 코드 리뷰 시, 새로 추가된 DTO와 메서드 분리에 대해 중점적으로 확인해 주시면 감사하겠습니다.
