### PR TITLE
[✨ feat/#116] [2차] 홈화면 > 오늘 마감되는 관심공고에서 홈화면 > 곧 마감되는 관심 공고로 변경

### DIFF
--- a/src/main/java/org/terning/terningserver/config/SwaggerConfig.java
+++ b/src/main/java/org/terning/terningserver/config/SwaggerConfig.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         servers = {
                 @Server(url = "https://www.terning-official.p-e.kr", description = "Default Server url"),
-                @Server(url = "http://15.165.242.132", description = "Staging Server URL")
+                @Server(url = "http://15.165.242.132", description = "Staging Server URL"),
+                @Server(url = "http://localhost:8080", description = "Local Development Server URL")
         }
 )
 public class SwaggerConfig {

--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -6,19 +6,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.HomeSwagger;
 import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
-import org.terning.terningserver.dto.user.response.HomeResponseDto;
-import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
-import org.terning.terningserver.exception.CustomException;
-import org.terning.terningserver.exception.dto.ErrorResponse;
+import org.terning.terningserver.dto.user.response.UpcomingScrapResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
-import org.terning.terningserver.exception.enums.SuccessMessage;
 import org.terning.terningserver.service.HomeService;
 import org.terning.terningserver.service.ScrapService;
 
 import java.util.List;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_ANNOUNCEMENTS;
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_TODAY_ANNOUNCEMENTS;
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_UPCOMING_ANNOUNCEMENTS;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,13 +36,13 @@ public class HomeController implements HomeSwagger {
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
     }
 
-    @GetMapping("/home/today")
-    public ResponseEntity<SuccessResponse<List<TodayScrapResponseDto>>> getTodayScraps(
+    @GetMapping("/home/upcoming")
+    public ResponseEntity<SuccessResponse<List<UpcomingScrapResponseDto>>> getUpcomingScraps(
             @AuthenticationPrincipal Long userId
     ){
 
-        List<TodayScrapResponseDto> scrapList = scrapService.getTodayScrap(userId);
+        List<UpcomingScrapResponseDto> scrapList = scrapService.getUpcomingScrap(userId);
 
-        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_TODAY_ANNOUNCEMENTS, scrapList));
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS, scrapList));
     }
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
-import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
+import org.terning.terningserver.dto.user.response.UpcomingScrapResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
 import java.util.List;
@@ -20,8 +20,8 @@ public interface HomeSwagger {
             int startMonth
     );
 
-    @Operation(summary = "홈화면 > 오늘 마감인 스크랩 공고 조회", description = "오늘 마감인 스크랩 공고를 조회하는 API")
-    ResponseEntity<SuccessResponse<List<TodayScrapResponseDto>>> getTodayScraps(
+    @Operation(summary = "홈화면 > 곧 마감인 스크랩 공고 조회", description = "곧 마감인 스크랩 공고를 조회하는 API")
+    ResponseEntity<SuccessResponse<List<UpcomingScrapResponseDto>>> getUpcomingScraps(
             Long userId
     );
 }

--- a/src/main/java/org/terning/terningserver/dto/user/response/UpcomingScrapResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/UpcomingScrapResponseDto.java
@@ -5,7 +5,7 @@ import org.terning.terningserver.domain.Scrap;
 import org.terning.terningserver.util.DateUtil;
 
 @Builder
-public record TodayScrapResponseDto(
+public record UpcomingScrapResponseDto(
         Long internshipAnnouncementId,
         String companyImage,
         String dDay,
@@ -16,10 +16,10 @@ public record TodayScrapResponseDto(
         String deadline,
         String startYearMonth
 ) {
-    public static TodayScrapResponseDto of(final Scrap scrap){
+    public static UpcomingScrapResponseDto of(final Scrap scrap){
         String startYearMonth = scrap.getInternshipAnnouncement().getStartYear() + "년 " + scrap.getInternshipAnnouncement().getStartMonth() + "월";
 
-        return TodayScrapResponseDto.builder()
+        return UpcomingScrapResponseDto.builder()
                 .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
                 .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
                 .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum SuccessMessage {
     // 홈 화면
     SUCCESS_GET_ANNOUNCEMENTS(200, "인턴 공고 불러오기를 성공했습니다"),
-    SUCCESS_GET_TODAY_ANNOUNCEMENTS(200, "오늘 마감인 인턴 공고 요청을 성공했습니다"),
+    SUCCESS_GET_UPCOMING_ANNOUNCEMENTS(200, "곧 마감인 인턴 공고 요청을 성공했습니다"),
 
     // 소셜 로그인
     SUCCESS_SIGN_IN(200, "소셜 로그인에 성공하였습니다"),

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
@@ -12,7 +12,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
 
     Optional<Scrap> findByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
 
-    List<Scrap> findByUserIdAndInternshipAnnouncement_Deadline(Long userId, LocalDate deadline);
+//    List<Scrap> findByUserIdAndInternshipAnnouncement_Deadline(Long userId, LocalDate deadline);
 
     List<Scrap> findByUserIdAndInternshipAnnouncement_DeadlineBetween(Long userId, LocalDate start, LocalDate end);
 

--- a/src/main/java/org/terning/terningserver/service/ScrapService.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapService.java
@@ -5,13 +5,13 @@ import org.terning.terningserver.dto.scrap.request.UpdateScrapRequestDto;
 import org.terning.terningserver.dto.calendar.response.DailyScrapResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
-import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
+import org.terning.terningserver.dto.user.response.UpcomingScrapResponseDto;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface ScrapService {
-    List<TodayScrapResponseDto> getTodayScrap(Long userId);
+    List<UpcomingScrapResponseDto> getUpcomingScrap(Long userId);
 
     void createScrap(Long internshipAnnouncementId, CreateScrapRequestDto request, Long userId);
 

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -12,7 +12,7 @@ import org.terning.terningserver.dto.scrap.request.UpdateScrapRequestDto;
 import org.terning.terningserver.dto.calendar.response.DailyScrapResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyDefaultResponseDto;
 import org.terning.terningserver.dto.calendar.response.MonthlyListResponseDto;
-import org.terning.terningserver.dto.user.response.TodayScrapResponseDto;
+import org.terning.terningserver.dto.user.response.UpcomingScrapResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 import org.terning.terningserver.repository.scrap.ScrapRepository;
@@ -37,10 +37,11 @@ public class ScrapServiceImpl implements ScrapService {
     private final UserRepository userRepository;
 
     @Override
-    public List<TodayScrapResponseDto> getTodayScrap(Long userId){
+    public List<UpcomingScrapResponseDto> getUpcomingScrap(Long userId){
         LocalDate today = LocalDate.now();
-        return scrapRepository.findByUserIdAndInternshipAnnouncement_Deadline(userId, today).stream()
-                .map(TodayScrapResponseDto::of)
+        LocalDate oneWeekFromToday = today.plusDays(7);
+        return scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(userId, today, oneWeekFromToday).stream()
+                .map(UpcomingScrapResponseDto::of)
                 .toList();
     }
 


### PR DESCRIPTION
# 📄 Work Description
1. 홈화면 상단 - `[오늘 마감되는 공고]`를 `[곧 마감되는 공고]`로 변경합니다.
- 사용자가 스크랩한 공고 중 D-DAY ~ D-7 사이에 마감되는 공고를 조회하는 API 입니다.
- 표시되는 공고 데이터가 `D-DAY` 에서 `D-DAY ~ D-7`로 변경되었습니다.
- 표시되는 공고 데이터는 `deadline`이 빠른 순으로(D-day에 가까울수록 먼저) 정렬해서 보내주도록 구현하였습니다.
- 해당 기능은 유저가 자신이 스크랩한 공고에 대한 일정을 확인하고 관리하기 위한 기능인데, 당장 마감이 코앞인 디데이 공고만 띄워주는 것보단, 곧 마감되는 (마감이 임박한) 공고들을 띄워주는 것이 유저에게 더 필요한 기능이라고 생각이 들어 변경합니다.(`기획`)

# ⚙️ ISSUE
- closed #116 


# 📷 Screenshot
### Swagger(200) : 스크랩된 공고가 없는 경우
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/ca4fb609-e46a-4de1-93f6-3b787321131d">

### Swagger(200) : 스크랩한 공고가 존재하고, 마감기한이 7일 이내인 공고가 존재하는 경우
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/48a74a69-3491-47e8-9359-18c7a8aacfad">
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/c4ddf2fa-e28d-4237-b691-ef05f9920258">
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/336c542a-44f3-4cd2-848c-c0959baa2052">


# 💬 To Reviewers
코드의 잘못된 부분이 있거나 피드백 사항이 있다면 언제든지 코드리뷰 남겨주세요:)


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
