### PR TITLE
[✨ feat/#123] 마이페이지 > 프로필 정보 이미지 전달방식 변경 & 마이페이지 > 프로필 수정 기능 추가

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/UserProfileController.java
+++ b/src/main/java/org/terning/terningserver/controller/UserProfileController.java
@@ -1,18 +1,18 @@
 package org.terning.terningserver.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.UserSwagger;
+import org.terning.terningserver.dto.user.request.ProfileUpdateRequestDto;
 import org.terning.terningserver.dto.user.response.ProfileResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.UserService;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_PROFILE;
+import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_UPDATE_PROFILE;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,5 +27,14 @@ public class UserProfileController implements UserSwagger {
     ){
         ProfileResponseDto profile = userService.getProfile(userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_PROFILE, profile));
+    }
+
+    @PatchMapping("/mypage/profile")
+    public ResponseEntity<SuccessResponse> updateProfile(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ProfileUpdateRequestDto request
+    ){
+        userService.updateProfile(userId, request);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_PROFILE));
     }
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/UserSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/UserSwagger.java
@@ -3,6 +3,7 @@ package org.terning.terningserver.controller.swagger;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.terning.terningserver.dto.user.request.ProfileUpdateRequestDto;
 import org.terning.terningserver.dto.user.response.ProfileResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
@@ -11,6 +12,13 @@ public interface UserSwagger {
 
     @Operation(summary = "마이페이지 > 프로필 정보 불러오기", description = "마이페이지에서 프로필 정보를 불러오는 API")
     ResponseEntity<SuccessResponse<ProfileResponseDto>> getProfile(
-        Long userId
+            Long userId
     );
+
+    @Operation(summary = "마이페이지 > 프로필 정보 수정하기", description = "마이페이지에서 프로필 정보를 수정하는 API")
+    ResponseEntity<SuccessResponse> updateProfile(
+            Long userId,
+            ProfileUpdateRequestDto request
+    );
+
 }

--- a/src/main/java/org/terning/terningserver/domain/User.java
+++ b/src/main/java/org/terning/terningserver/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.terning.terningserver.domain.common.BaseTimeEntity;
 import org.terning.terningserver.domain.enums.AuthType;
+import org.terning.terningserver.domain.enums.ProfileImage;
 import org.terning.terningserver.domain.enums.State;
 import org.terning.terningserver.exception.CustomException;
 
@@ -37,8 +38,9 @@ public class User extends BaseTimeEntity {
     // TODO: 특수문자, 첫글자 , 12자리 이내
     @Column(length = 12)
     private String name; // 사용자 이름
-    
-    private Integer profileImage; //유저 아이콘
+
+    @Enumerated(STRING)
+    private ProfileImage profileImage; //유저 아이콘
 
     @Enumerated(STRING)
     private AuthType authType; // 인증 유형 (예: 카카오, 애플)
@@ -67,5 +69,11 @@ public class User extends BaseTimeEntity {
 
     public void assignFilter(Filter filter) {
         this.filter = filter;
+    }
+
+    //프로필 수정 메서드
+    public void updateProfile(String name, ProfileImage profileImage){
+        this.name = name;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/org/terning/terningserver/domain/enums/ProfileImage.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/ProfileImage.java
@@ -1,0 +1,28 @@
+package org.terning.terningserver.domain.enums;
+
+public enum ProfileImage {
+    BASIC("basic"),
+    LUCKY("lucky"),
+    SMART("smart"),
+    GLASS("glass"),
+    CALENDAR("calendar");
+
+    private final String value;
+
+    ProfileImage(String value){
+        this.value = value;
+    }
+
+    public String getValue(){
+        return value;
+    }
+
+    public static ProfileImage fromValue(String value){
+        for(ProfileImage image : values()){
+            if(image.value.equalsIgnoreCase(value)){
+                return image;
+            }
+        }
+        throw new IllegalArgumentException("Invalid profile image: " + value);
+    }
+}

--- a/src/main/java/org/terning/terningserver/domain/enums/ProfileImage.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/ProfileImage.java
@@ -1,5 +1,10 @@
 package org.terning.terningserver.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum ProfileImage {
     BASIC("basic"),
     LUCKY("lucky"),
@@ -8,14 +13,6 @@ public enum ProfileImage {
     CALENDAR("calendar");
 
     private final String value;
-
-    ProfileImage(String value){
-        this.value = value;
-    }
-
-    public String getValue(){
-        return value;
-    }
 
     public static ProfileImage fromValue(String value){
         for(ProfileImage image : values()){

--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpRequestDto.java
@@ -9,11 +9,11 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public record SignUpRequestDto(
         @NonNull String name,
-        int profileImage,
+        String profileImage,
         @NonNull AuthType authType
 ) {
 
-        public static SignUpRequestDto of(String name, int profileImage, AuthType authType){
+        public static SignUpRequestDto of(String name, String profileImage, AuthType authType){
             return SignUpRequestDto.builder()
                     .name(name)
                     .profileImage(profileImage)

--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpWithAuthIdRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpWithAuthIdRequestDto.java
@@ -10,10 +10,10 @@ import static lombok.AccessLevel.*;
 public record SignUpWithAuthIdRequestDto(
         @NonNull String authId,
         @NonNull String name,
-        int profileImage,
+        String profileImage,
         @NonNull AuthType authType
 ) {
-    public static SignUpWithAuthIdRequestDto of(String authId, String name, int profileImage, AuthType authType){
+    public static SignUpWithAuthIdRequestDto of(String authId, String name, String profileImage, AuthType authType){
         return SignUpWithAuthIdRequestDto.builder()
                 .authId(authId)
                 .name(name)

--- a/src/main/java/org/terning/terningserver/dto/user/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/request/ProfileUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package org.terning.terningserver.dto.user.request;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record ProfileUpdateRequestDto(
+        @NonNull String name,
+        String profileImage
+) {
+    public static ProfileUpdateRequestDto of(String name, String profileImage){
+        return ProfileUpdateRequestDto.builder()
+                .name(name)
+                .profileImage(profileImage)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/dto/user/response/ProfileResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/ProfileResponseDto.java
@@ -6,11 +6,13 @@ import org.terning.terningserver.domain.User;
 @Builder
 public record ProfileResponseDto(
         String name,
+        String profileImage,
         String authType
 ) {
     public static ProfileResponseDto of(final User user){
         return ProfileResponseDto.builder()
                 .name(user.getName())
+                .profileImage(user.getProfileImage().getValue()) // Enum to String
                 .authType(user.getAuthType().name().toUpperCase())
                 .build();
     }

--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -23,7 +23,7 @@ public enum ErrorMessage {
     FAILED_SIGN_UP_USER_FILTER_CREATION(404, "사용자 필터 생성에 실패하였습니다"),
     FAILED_SIGN_UP_USER_FILTER_ASSIGNMENT(404, "사용자 필터 연결에 실패하였습니다"),
 
-    //스크랩
+    // 스크랩
     EXISTS_SCRAP_ALREADY(400, "이미 스크랩했습니다."),
 
     // 로그 아웃
@@ -32,8 +32,11 @@ public enum ErrorMessage {
 
     // 계정 탈퇴
     FAILED_WITHDRAW(404, "계정 탈퇴에 실패하였습니다"),
+
+    // 마이페이지
+    INVALID_PROFILE_IMAGE(404, "유효하지 않은 프로필 이미지 입니다."),
     
-    //404(NotFound)
+    // 404(NotFound)
     NOT_FOUND_INTERN_CATEGORY(404, "해당 인턴 공고는 존재하지 않습니다"),
     NOT_FOUND_INTERN_EXCEPTION(404, "해당 인턴 공고는 존재하지 않습니다"),
     NOT_FOUND_USER_EXCEPTION(404, "해당 유저가 존재하지 않습니다"),

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -52,8 +52,8 @@ public enum SuccessMessage {
     SUCCESS_UPDATE_USER_FILTER(200, "필터링 재설정에 성공했습니다"),
 
     // My page (마이페이지 화면)
-    SUCCESS_GET_PROFILE(200, "마이페이지 > 프로필 정보 불러오기를 성공했습니다");
-
+    SUCCESS_GET_PROFILE(200, "마이페이지 > 프로필 정보 불러오기를 성공했습니다"),
+    SUCCESS_UPDATE_PROFILE(200, "프로필 수정에 성공했습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import org.terning.terningserver.domain.Filter;
 import org.terning.terningserver.domain.Token;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
+import org.terning.terningserver.domain.enums.ProfileImage;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
 import org.terning.terningserver.dto.auth.request.SignInRequestDto;
 import org.terning.terningserver.dto.auth.request.SignUpFilterRequestDto;
@@ -149,11 +150,15 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private User createUser(SignUpWithAuthIdRequestDto requestDto) {
+        //프로필 이미지가 null일 경우 기본값 "basic"으로 설정
+        ProfileImage profileImage = requestDto.profileImage() != null
+                ? ProfileImage.fromValue(requestDto.profileImage()) : ProfileImage.BASIC;
+
         User user = User.builder()
                 .authId(requestDto.authId())
                 .name(requestDto.name())
                 .authType(requestDto.authType())
-                .profileImage(requestDto.profileImage())
+                .profileImage(profileImage) //String to Enum
                 .build();
         return userRepository.save(user);
     }

--- a/src/main/java/org/terning/terningserver/service/UserService.java
+++ b/src/main/java/org/terning/terningserver/service/UserService.java
@@ -1,9 +1,12 @@
 package org.terning.terningserver.service;
 
 import org.terning.terningserver.domain.User;
+import org.terning.terningserver.dto.user.request.ProfileUpdateRequestDto;
 import org.terning.terningserver.dto.user.response.ProfileResponseDto;
 
 public interface UserService {
     void deleteUser(User user);
     ProfileResponseDto getProfile(Long userId);
+
+    void updateProfile(Long userId, ProfileUpdateRequestDto request);
 }

--- a/src/main/java/org/terning/terningserver/service/UserServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/UserServiceImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.User;
+import org.terning.terningserver.domain.enums.ProfileImage;
+import org.terning.terningserver.dto.user.request.ProfileUpdateRequestDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.exception.enums.ErrorMessage;
 import org.terning.terningserver.repository.user.UserRepository;
@@ -32,6 +34,28 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION)
         );
+
         return ProfileResponseDto.of(user);
+    }
+
+    @Override
+    @Transactional
+    public void updateProfile(Long userId, ProfileUpdateRequestDto request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(
+                        () -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION));
+
+        try{
+            // 프로필 이미지가 유효하지 않으면 IllegalArgumentException을 던짐
+            ProfileImage profileImage = ProfileImage.fromValue(request.profileImage());
+
+            //프로필 업데이트
+            user.updateProfile(request.name(), ProfileImage.fromValue(request.profileImage()));
+
+            userRepository.save(user);
+        } catch (IllegalArgumentException e){
+            // 잘못된 프로필 이미지 값이 오면 CustomException 발생
+            throw new CustomException(ErrorMessage.INVALID_PROFILE_IMAGE);
+        }
     }
 }

--- a/src/main/java/org/terning/terningserver/service/UserServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/UserServiceImpl.java
@@ -42,8 +42,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void updateProfile(Long userId, ProfileUpdateRequestDto request){
         User user = userRepository.findById(userId)
-                .orElseThrow(
-                        () -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION));
+                .orElseThrow(() -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION));
 
         try{
             // 프로필 이미지가 유효하지 않으면 IllegalArgumentException을 던짐


### PR DESCRIPTION
# 📄 Work Description
- profileImage를 기존에 int 형 인덱스 값에서 ENUM 타입(String) 값으로 변경함에 따라 ENUM 파일을 새로 작성해 주었습니다.
- 온보딩 > 회원가입 API에서 profileImage를 `int` 타입에서 `String` 타입으로 전달 받도록 변경했습니다.
(6개의 String Enum 타입 중 하나: `basic`, `lucky`, `smart`, `glass`, `calendar`, `passion`)
  - 프로필 이미지가 null인 경우 기본값인 `basic` 으로 설정되도록 구현하였습니다.
- 마이페이지 > 프로필 정보 불러오기 API에서 profileImage를 함께 보내주도록 response를 수정하였습니다.
(6개의 String Enum 타입 중 하나: `basic`, `lucky`, `smart`, `glass`, `calendar`, `passion`)
- 마이페이지 > 프로필 수정 기능을 추가했습니다.
  - 유효하지 않은 프로필 이미지로 수정을 시도할 경우, 예외처리 하여 CustomException을 발생시키도록 구현하였습니다.


# ⚙️ ISSUE
- closed #123 


# 📷 Screenshot
### 1. 회원가입 API : profileImage 전달방식 변경 `int` >> `String`
<img width="951" alt="image" src="https://github.com/user-attachments/assets/5e1fa572-9fe6-4fbf-9e98-596414fef4af">

### 2. 프로필 정보 불러오기 API : profileImage를 추가로 전달하도록 응답 수정
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/1041a20e-6e3b-4947-bd1b-7adbbf619435">

### 3. 프로필 수정하기 API 
- case 1) Swagger 200
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/32d159da-9a30-4a69-9a16-b3cc92d1bc5c">


- case 2) Swagger 404 : 유효하지 않은 프로필 이미지로 수정을 시도할 경우
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/b4eea58a-09e9-42f9-b057-bbda915a4fdd">


# 💬 To Reviewers
기존의 코드와 변경된 부분이 많고, 회원가입 로직에 코드를 추가했기 때문에 꼼꼼하게 확인해주시면 감사하겠습니다:)

잘못된 부분이 있거나 개선할 부분이 있다면 편하게 말씀해주세요!


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
