### PR TITLE
[♻️ refactor/#127]: 필터링 관련 API 수정 및 Spring AOP를 사용한 성능테스트 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 	// gson
 	implementation 'com.google.code.gson:gson:2.8.6'
 
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 }
 
 //QueryDSL 초기 설정

--- a/src/main/java/org/terning/terningserver/controller/FilterController.java
+++ b/src/main/java/org/terning/terningserver/controller/FilterController.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.FilterSwagger;
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.FilterService;
@@ -32,7 +32,8 @@ public class FilterController implements FilterSwagger {
     @PutMapping("/filters")
     public ResponseEntity<SuccessResponse> updateUserFilter(
             @AuthenticationPrincipal Long userId,
-            @RequestBody UserFilterRequestDto requestDto) {
+            @RequestBody UpdateUserFilterRequestDto requestDto
+    ) {
         filterService.updateUserFilter(requestDto, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_USER_FILTER));
     }

--- a/src/main/java/org/terning/terningserver/controller/FilterController.java
+++ b/src/main/java/org/terning/terningserver/controller/FilterController.java
@@ -21,7 +21,7 @@ public class FilterController implements FilterSwagger {
 
     @GetMapping("/filters")
     public ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal long userId
     ) {
         return ResponseEntity.ok(SuccessResponse.of(
                 SUCCESS_GET_USER_FILTER,
@@ -31,7 +31,7 @@ public class FilterController implements FilterSwagger {
 
     @PutMapping("/filters")
     public ResponseEntity<SuccessResponse> updateUserFilter(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal long userId,
             @RequestBody UpdateUserFilterRequestDto requestDto
     ) {
         filterService.updateUserFilter(requestDto, userId);

--- a/src/main/java/org/terning/terningserver/controller/FilterController.java
+++ b/src/main/java/org/terning/terningserver/controller/FilterController.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.FilterSwagger;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.FilterService;
 
@@ -20,7 +20,7 @@ public class FilterController implements FilterSwagger {
     private final FilterService filterService;
 
     @GetMapping("/filters")
-    public ResponseEntity<SuccessResponse<UserFilterResponseDto>> getUserFilter(
+    public ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
             @AuthenticationPrincipal Long userId
     ) {
         return ResponseEntity.ok(SuccessResponse.of(

--- a/src/main/java/org/terning/terningserver/controller/ScrapController.java
+++ b/src/main/java/org/terning/terningserver/controller/ScrapController.java
@@ -10,6 +10,7 @@ import org.terning.terningserver.dto.scrap.request.UpdateScrapRequestDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.jwt.PrincipalHandler;
 import org.terning.terningserver.service.ScrapService;
+import org.terning.terningserver.util.LogExecutionTime;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.*;
 

--- a/src/main/java/org/terning/terningserver/controller/ScrapController.java
+++ b/src/main/java/org/terning/terningserver/controller/ScrapController.java
@@ -22,8 +22,8 @@ public class ScrapController implements ScrapSwagger {
 
     @PostMapping("/scraps/{internshipAnnouncementId}")
     public ResponseEntity<SuccessResponse> createScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId,
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId,
             @RequestBody CreateScrapRequestDto request) {
         scrapService.createScrap(internshipAnnouncementId, request, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_CREATE_SCRAP));
@@ -31,16 +31,16 @@ public class ScrapController implements ScrapSwagger {
 
     @DeleteMapping("/scraps/{internshipAnnouncementId}")
     public ResponseEntity<SuccessResponse> deleteScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId) {
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId) {
         scrapService.deleteScrap(internshipAnnouncementId, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_DELETE_SCRAP));
     }
 
     @PatchMapping("/scraps/{internshipAnnouncementId}")
     public ResponseEntity<SuccessResponse> updateScrapColor(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId,
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId,
             @RequestBody UpdateScrapRequestDto request) {
         scrapService.updateScrapColor(internshipAnnouncementId, request, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_SCRAP));

--- a/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
@@ -6,8 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
@@ -22,6 +21,6 @@ public interface FilterSwagger {
     @Operation(summary = "사용자 필터링 정보 수정 API", description = "사용자 필터링을 수정하는 API")
     ResponseEntity<SuccessResponse> updateUserFilter(
             @AuthenticationPrincipal Long userId,
-            @RequestBody UserFilterRequestDto requestDto
+            @RequestBody UpdateUserFilterRequestDto requestDto
     );
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
@@ -7,14 +7,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
 @Tag(name = "Filter", description = "사용자 필터링 관련 API")
 public interface FilterSwagger {
 
     @Operation(summary = "사용자 필터링 정보 조회 API", description = "사용자가 설정한 필터링 정보를 조회하는 API")
-    ResponseEntity<SuccessResponse<UserFilterResponseDto>> getUserFilter(
+    ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
             @AuthenticationPrincipal Long userId
     );
 

--- a/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
@@ -15,12 +15,12 @@ public interface FilterSwagger {
 
     @Operation(summary = "사용자 필터링 정보 조회 API", description = "사용자가 설정한 필터링 정보를 조회하는 API")
     ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal long userId
     );
 
     @Operation(summary = "사용자 필터링 정보 수정 API", description = "사용자 필터링을 수정하는 API")
     ResponseEntity<SuccessResponse> updateUserFilter(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal long userId,
             @RequestBody UpdateUserFilterRequestDto requestDto
     );
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/ScrapSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/ScrapSwagger.java
@@ -15,20 +15,21 @@ public interface ScrapSwagger {
 
     @Operation(summary = "스크랩 추가", description = "사용자가 스크랩을 추가하는 API")
     ResponseEntity<SuccessResponse> createScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId, @RequestBody CreateScrapRequestDto request
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId,
+            @RequestBody CreateScrapRequestDto request
     );
 
     @Operation(summary = "스크랩 취소", description = "사용자가 스크랩을 취소하는 API")
     ResponseEntity<SuccessResponse> deleteScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId
     );
 
     @Operation(summary = "스크랩 수정", description = "사용자가 스크랩 색상을 수정하는 API")
     public ResponseEntity<SuccessResponse> updateScrapColor(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long scrapId,
+            @AuthenticationPrincipal long userId,
+            @PathVariable long scrapId,
             @RequestBody UpdateScrapRequestDto request
     );
 

--- a/src/main/java/org/terning/terningserver/domain/enums/Color.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Color.java
@@ -4,6 +4,10 @@ package org.terning.terningserver.domain.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Getter
 public enum Color {
@@ -22,7 +26,16 @@ public enum Color {
     private final String name;
     private final String value;
 
+    private static final Map<String, Color> colorMap =
+            Arrays.stream(Color.values())
+                    .collect(Collectors.toMap(Color::getName, color -> color));
+
     public String getColorValue() {
         return "#" + value;
     }
+
+    public static Color findByName(String name) {
+        return colorMap.get(name);
+    }
+
 }

--- a/src/main/java/org/terning/terningserver/domain/enums/Grade.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Grade.java
@@ -6,17 +6,17 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Grade {
-    FRESHMAN(0, "1학년"),
-    SOPHOMORE(1, "2학년"),
-    JUNIOR(2, "3학년"),
-    SENIOR(3, "4학년");
+    FRESHMAN("freshman", "1학년"),
+    SOPHOMORE("sophomore", "2학년"),
+    JUNIOR("junior", "3학년"),
+    SENIOR("senior", "4학년");
 
-    private final int key;
+    private final String key;
     private final String value;
     
-    public static Grade fromKey(int key){
+    public static Grade fromKey(String key){
         for(Grade grade : Grade.values()){
-            if(grade.key == key){
+            if(grade.key.equals(key)){
                 return grade;
             }
         }

--- a/src/main/java/org/terning/terningserver/domain/enums/WorkingPeriod.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/WorkingPeriod.java
@@ -7,16 +7,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum WorkingPeriod {
-    OPTION1(0, "1개월 ~ 3개월"),
-    OPTION2(1, "4개월 ~ 6개월"),
-    OPTION3(2, "7개월 이상");
+    OPTION1("short", "1개월 ~ 3개월"),
+    OPTION2("middle", "4개월 ~ 6개월"),
+    OPTION3("long", "7개월 이상");
 
-    private final int key;
+    private final String key;
     private final String value;
 
-    public static WorkingPeriod fromKey(int key){
+    public static WorkingPeriod fromKey(String key){
         for(WorkingPeriod period : WorkingPeriod.values()){
-            if(period.key == key){
+            if(period.key.equals(key)){
                 return period;
             }
         }

--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpFilterRequestDto.java
@@ -7,13 +7,13 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record SignUpFilterRequestDto(
-        int grade,
-        int workingPeriod,
+        String grade,
+        String workingPeriod,
         int startYear,
         int startMonth
 
 ) {
-    public static SignUpFilterRequestDto of(int grade, int workingPeriod, int startYear, int startMonth) {
+    public static SignUpFilterRequestDto of(String grade, String workingPeriod, int startYear, int startMonth) {
         return SignUpFilterRequestDto.builder()
                 .grade(grade)
                 .workingPeriod(workingPeriod)

--- a/src/main/java/org/terning/terningserver/dto/filter/request/UpdateUserFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/request/UpdateUserFilterRequestDto.java
@@ -1,8 +1,8 @@
 package org.terning.terningserver.dto.filter.request;
 
-public record UserFilterRequestDto(
-        int grade,
-        int workingPeriod,
+public record UpdateUserFilterRequestDto(
+        String grade,
+        String workingPeriod,
         int startYear,
         int startMonth
 ) {

--- a/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 import org.terning.terningserver.domain.Filter;
 
 @Builder
-public record UserFilterResponseDto(
-        Integer grade,
-        Integer workingPeriod,
+public record UserFilterDetailResponseDto(
+        String grade,
+        String workingPeriod,
         Integer startYear,
         Integer startMonth
 ) {
-    public static UserFilterResponseDto of(Filter userFilter) {
-        return UserFilterResponseDto.builder()
+    public static UserFilterDetailResponseDto of(Filter userFilter) {
+        return UserFilterDetailResponseDto.builder()
                 .grade(userFilter == null ? null : userFilter.getGrade().getKey())
                 .workingPeriod(userFilter == null ? null : userFilter.getWorkingPeriod().getKey())
                 .startYear(userFilter == null ? null : userFilter.getStartYear())

--- a/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
@@ -3,14 +3,16 @@ package org.terning.terningserver.dto.filter.response;
 import lombok.Builder;
 import org.terning.terningserver.domain.Filter;
 
-@Builder
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
 public record UserFilterDetailResponseDto(
         String grade,
         String workingPeriod,
         Integer startYear,
         Integer startMonth
 ) {
-    public static UserFilterDetailResponseDto of(Filter userFilter) {
+    public static UserFilterDetailResponseDto of(final Filter userFilter) {
         return UserFilterDetailResponseDto.builder()
                 .grade(userFilter == null ? null : userFilter.getGrade().getKey())
                 .workingPeriod(userFilter == null ? null : userFilter.getWorkingPeriod().getKey())

--- a/src/main/java/org/terning/terningserver/service/FilterService.java
+++ b/src/main/java/org/terning/terningserver/service/FilterService.java
@@ -1,11 +1,11 @@
 package org.terning.terningserver.service;
 
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 
 public interface FilterService {
 
     UserFilterResponseDto getUserFilter(Long userId);
 
-    void updateUserFilter(UserFilterRequestDto responseDto, Long userId);
+    void updateUserFilter(UpdateUserFilterRequestDto responseDto, Long userId);
 }

--- a/src/main/java/org/terning/terningserver/service/FilterService.java
+++ b/src/main/java/org/terning/terningserver/service/FilterService.java
@@ -1,11 +1,11 @@
 package org.terning.terningserver.service;
 
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 
 public interface FilterService {
 
-    UserFilterResponseDto getUserFilter(Long userId);
+    UserFilterDetailResponseDto getUserFilter(Long userId);
 
     void updateUserFilter(UpdateUserFilterRequestDto responseDto, Long userId);
 }

--- a/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
@@ -8,7 +8,7 @@ import org.terning.terningserver.domain.Filter;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.repository.filter.FilterRepository;
@@ -31,7 +31,7 @@ public class FilterServiceImpl implements FilterService {
 
     @Override
     @Transactional
-    public void updateUserFilter(UserFilterRequestDto responseDto, Long userId) {
+    public void updateUserFilter(UpdateUserFilterRequestDto responseDto, Long userId) {
         User user = findUser(userId);
         Filter filter = user.getFilter();
         if(filter != null){

--- a/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
@@ -9,7 +9,7 @@ import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.repository.filter.FilterRepository;
 import org.terning.terningserver.repository.user.UserRepository;
@@ -25,8 +25,8 @@ public class FilterServiceImpl implements FilterService {
     private final FilterRepository filterRepository;
 
     @Override
-    public UserFilterResponseDto getUserFilter(Long userId) {
-       return UserFilterResponseDto.of(findUser(userId).getFilter());
+    public UserFilterDetailResponseDto getUserFilter(Long userId) {
+       return UserFilterDetailResponseDto.of(findUser(userId).getFilter());
     }
 
     @Override

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -19,6 +19,7 @@ import org.terning.terningserver.repository.internship_announcement.InternshipRe
 import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
 import org.terning.terningserver.util.DateUtil;
+import org.terning.terningserver.util.LogExecutionTime;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -148,7 +149,7 @@ public class ScrapServiceImpl implements ScrapService {
     public void updateScrapColor(Long internshipAnnouncementId, UpdateScrapRequestDto request, Long userId) {
         Scrap scrap = findScrap(internshipAnnouncementId, userId);
         verifyScrapOwner(scrap, userId);
-        scrap.updateColor(findColor(request.color()));
+        scrap.updateColor(Color.findByName(request.color()));
     }
 
     //토큰으로 찾은(요청한) User와 스크랩한 User가 일치한지 여부 검증하는 메서드

--- a/src/main/java/org/terning/terningserver/util/LogAspect.java
+++ b/src/main/java/org/terning/terningserver/util/LogAspect.java
@@ -1,0 +1,37 @@
+package org.terning.terningserver.util;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.hibernate.type.descriptor.java.ObjectJavaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class LogAspect {
+
+    Logger logger = LoggerFactory.getLogger(LogAspect.class);
+
+    @Around("@annotation(LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        //@LogExecutionTime이 붙어있는 타켓 메소드의 성능 측정
+        Object proceed = joinPoint.proceed();
+
+        stopWatch.stop();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        logger.info("실행한 메소드: " + signature.getMethod().getName());
+        logger.info("수행 시간: " + stopWatch.getTotalTimeMillis() + "ms");
+
+        return proceed;
+    }
+}

--- a/src/main/java/org/terning/terningserver/util/LogExecutionTime.java
+++ b/src/main/java/org/terning/terningserver/util/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package org.terning.terningserver.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}


### PR DESCRIPTION
# 📄 Work Description
- 필터링 관련 API 수정 및 Spring AOP를 사용한 성능테스트 환경 구축

# ⚙️ ISSUE
- closed #127 


# 📷 Screenshot
 - 필터링 재설정
![image](https://github.com/user-attachments/assets/6b98ec3d-cbff-4f25-89c1-c4cef1e8ff5f)

 - 사용자 필터링 정보 조회
![image](https://github.com/user-attachments/assets/54523f75-7957-4bb6-8c1f-c7af79531f80)


# 💬 To Reviewers

> 필터링 관련 API 2개 데이터 형식 변경
- 지난 클-서 회의때 인덱스 값을 `int`에서 `String`으로 보내기로 데이터형식을 맞추었기에 해당 2개의 API에서 `workingPeriod`와 `grade` 필드의 타입이 기존 `int`에서 `String`으로 변경되었습니다.

  ✚ 추가) 사용자 필터링 생성 API도 `WorkingPeriod`와 `Grade` enum의 `key` 타입이 변경됨에 따라 약간의 수정이 있었습니다! 해당사항 수정 후 API 테스트까지 잘 되는 것 확인했습니다.

<br/>

> Spring AOP를 사용한 성능테스트 환경 구축
- 이전 PR에서 정교님께서 findColor()시에 색상수정은 번번하게 일어날 것 같아서 순회탐색보다는 map을 통한 캐싱을 추천해주셨는데요!
해당 사항을 참고하여 두 방안에 대한 성능테스트를 진행해보았습니다.

1. 기존 순회 탐색의 경우
- 시간 복잡도: O(n) / 데이터 개수 n개일 경우
```java
private Color findColor(String color) {
    return Arrays.stream(Color.values())
            .filter(c-> c.getName().equals(color))
            .findAny().get();
}
```
![image](https://github.com/user-attachments/assets/08e97c21-9ea6-4501-9b37-30d1c63274b6)

<br/>

2. map을 사용한 캐싱
- 시간 복잡도: O(1)
```java
private static final Map<String, Color> colorMap =
        Arrays.stream(Color.values())
                .collect(Collectors.toMap(Color::getName, color -> color));

public String getColorValue() {
    return "#" + value;
}

public static Color findByName(String name) {
    return colorMap.get(name);
}
```
![image](https://github.com/user-attachments/assets/6af1d477-0db6-4e0e-bef0-c100b2d6fc17)

<br/>

🔆 성능 테스트 결과 
- 몇 번 테스트를 해봤을 때 1번으로 할 때 시간이 더 적게 찍히기도 하고 2번이 더 적게 찍히기도 했습니다. 
   제 예상으로는 현재 Color의 개수가 10개로 굉장히 적어서 성능상의 큰 차이가 없는 것으로 보입니다. 하지만 Color 개수가 늘어나고, 색상 수정이 훨씬 빈번히 일어난다면 `2. map을 사용한 캐싱`이 성능상으로 더 좋을 것으로 생각되어 우선 후자의 방안을 선택했습니다.

<br/>

> Spring AOP를 사용한 성능테스트 환경 구축
- 성능 테스트를 할 수 있는 방법이 여러가지가 있는데, 그 중 가장 간단하게 테스트를 할 수 있는 방법을 선택했습니다. 현재는 메소드 실행시간 측정을 통한 API 성능테스트가 가능합니다. 

- Spring AOP를 사용하여 성능테스트를 한 이유
   1. 핵심 기능과 부가 기능 분리

  아래와 같이 중요 핵심 비즈니스 로직에 부가적인 기능(성능측정)을 위한 코드를 추가하게되면, 관심사 분리가 잘 되지 않으며 코드의 가독성이 떨어진다는 문제점이 있습니다. 
  
  ```java
  public void doSomething(HttpServletRequest request){
	  long startTime = System.nanoTime();
  
	  //do something
  
	  long finishTime = System.nanoTime();
	  System.out.print("메소드 실행 시간(ns): " + (finishTime - startTime));
  }
  ```
    <br/>
    따라서 Target을 설정하여 대상이 되는 메서드의 지정 부분(실행 직후, 종료 직전, 실행 종료)에 부가 기능을 수행할 수 있도록 했습니다.
    
    ```java
      @Target({ElementType.METHOD})
      @Retention(RetentionPolicy.RUNTIME)
      public @interface LogExecutionTime {
      }
    ```

    ```java
      @Component
      @Aspect
      @RequiredArgsConstructor
      public class LogAspect {
      
          Logger logger = LoggerFactory.getLogger(LogAspect.class);
      
          @Around("@annotation(LogExecutionTime)")
          public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
              StopWatch stopWatch = new StopWatch();
              stopWatch.start();
      
              //@LogExecutionTime이 붙어있는 타켓 메소드의 성능 측정
              Object proceed = joinPoint.proceed();
      
              stopWatch.stop();
      
              MethodSignature signature = (MethodSignature) joinPoint.getSignature();
              logger.info("실행한 메소드: " + signature.getMethod().getName());
              logger.info("수행 시간: " + stopWatch.getTotalTimeMillis() + "ms");
      
              return proceed;
          }
      }
    ```
    <br/>
    
    성능테스트를 하고 싶으시다면, 타켓 메서드에 아래와 같이 `@LogExecutionTime`를 붙여주시면 됩니다!
    ```java
        @Transactional
        @LogExecutionTime
        public void updateScrapColor(Long internshipAnnouncementId, UpdateScrapRequestDto request, Long userId) {
            Scrap scrap = findScrap(internshipAnnouncementId, userId);
            verifyScrapOwner(scrap, userId);
            scrap.updateColor(Color.findByName(request.color()));
        }
    ```

### 🤔고민되는 지점
성능테스트 관련 파일(`LogAspect.java`, `LogExecutionTime.java)을` util에 위치시켰는데, 혹시 괜찮을까요?

# 🔗 Reference
[블로그1](https://medium.com/mo-zza/performance-test-4-aop-timer-d40b99fa5b7c)
[블로그2](https://junghyungil.tistory.com/56)
[블로그3](https://velog.io/@jw_kim/spring-AOP%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%98%EC%97%AC-API-%EC%84%B1%EB%8A%A5-%EC%B8%A1%EC%A0%95%ED%95%98%EA%B8%B0-1-0undnr0v)