### PR TITLE
[♻️ refactor/#129]: 공고 상세 정보 및 검색 결과 화면 response body 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 	// gson
 	implementation 'com.google.code.gson:gson:2.8.6'
 
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 }
 
 //QueryDSL 초기 설정

--- a/src/main/java/org/terning/terningserver/controller/FilterController.java
+++ b/src/main/java/org/terning/terningserver/controller/FilterController.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.FilterSwagger;
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.FilterService;
@@ -32,7 +32,8 @@ public class FilterController implements FilterSwagger {
     @PutMapping("/filters")
     public ResponseEntity<SuccessResponse> updateUserFilter(
             @AuthenticationPrincipal Long userId,
-            @RequestBody UserFilterRequestDto requestDto) {
+            @RequestBody UpdateUserFilterRequestDto requestDto
+    ) {
         filterService.updateUserFilter(requestDto, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_USER_FILTER));
     }

--- a/src/main/java/org/terning/terningserver/controller/FilterController.java
+++ b/src/main/java/org/terning/terningserver/controller/FilterController.java
@@ -21,7 +21,7 @@ public class FilterController implements FilterSwagger {
 
     @GetMapping("/filters")
     public ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal long userId
     ) {
         return ResponseEntity.ok(SuccessResponse.of(
                 SUCCESS_GET_USER_FILTER,
@@ -31,7 +31,7 @@ public class FilterController implements FilterSwagger {
 
     @PutMapping("/filters")
     public ResponseEntity<SuccessResponse> updateUserFilter(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal long userId,
             @RequestBody UpdateUserFilterRequestDto requestDto
     ) {
         filterService.updateUserFilter(requestDto, userId);

--- a/src/main/java/org/terning/terningserver/controller/FilterController.java
+++ b/src/main/java/org/terning/terningserver/controller/FilterController.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.FilterSwagger;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.service.FilterService;
 
@@ -20,7 +20,7 @@ public class FilterController implements FilterSwagger {
     private final FilterService filterService;
 
     @GetMapping("/filters")
-    public ResponseEntity<SuccessResponse<UserFilterResponseDto>> getUserFilter(
+    public ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
             @AuthenticationPrincipal Long userId
     ) {
         return ResponseEntity.ok(SuccessResponse.of(

--- a/src/main/java/org/terning/terningserver/controller/ScrapController.java
+++ b/src/main/java/org/terning/terningserver/controller/ScrapController.java
@@ -10,6 +10,7 @@ import org.terning.terningserver.dto.scrap.request.UpdateScrapRequestDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 import org.terning.terningserver.jwt.PrincipalHandler;
 import org.terning.terningserver.service.ScrapService;
+import org.terning.terningserver.util.LogExecutionTime;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.*;
 

--- a/src/main/java/org/terning/terningserver/controller/ScrapController.java
+++ b/src/main/java/org/terning/terningserver/controller/ScrapController.java
@@ -22,8 +22,8 @@ public class ScrapController implements ScrapSwagger {
 
     @PostMapping("/scraps/{internshipAnnouncementId}")
     public ResponseEntity<SuccessResponse> createScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId,
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId,
             @RequestBody CreateScrapRequestDto request) {
         scrapService.createScrap(internshipAnnouncementId, request, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_CREATE_SCRAP));
@@ -31,16 +31,16 @@ public class ScrapController implements ScrapSwagger {
 
     @DeleteMapping("/scraps/{internshipAnnouncementId}")
     public ResponseEntity<SuccessResponse> deleteScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId) {
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId) {
         scrapService.deleteScrap(internshipAnnouncementId, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_DELETE_SCRAP));
     }
 
     @PatchMapping("/scraps/{internshipAnnouncementId}")
     public ResponseEntity<SuccessResponse> updateScrapColor(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId,
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId,
             @RequestBody UpdateScrapRequestDto request) {
         scrapService.updateScrapColor(internshipAnnouncementId, request, userId);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_SCRAP));

--- a/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
@@ -6,8 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
@@ -22,6 +21,6 @@ public interface FilterSwagger {
     @Operation(summary = "사용자 필터링 정보 수정 API", description = "사용자 필터링을 수정하는 API")
     ResponseEntity<SuccessResponse> updateUserFilter(
             @AuthenticationPrincipal Long userId,
-            @RequestBody UserFilterRequestDto requestDto
+            @RequestBody UpdateUserFilterRequestDto requestDto
     );
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
@@ -7,14 +7,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
 @Tag(name = "Filter", description = "사용자 필터링 관련 API")
 public interface FilterSwagger {
 
     @Operation(summary = "사용자 필터링 정보 조회 API", description = "사용자가 설정한 필터링 정보를 조회하는 API")
-    ResponseEntity<SuccessResponse<UserFilterResponseDto>> getUserFilter(
+    ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
             @AuthenticationPrincipal Long userId
     );
 

--- a/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/FilterSwagger.java
@@ -15,12 +15,12 @@ public interface FilterSwagger {
 
     @Operation(summary = "사용자 필터링 정보 조회 API", description = "사용자가 설정한 필터링 정보를 조회하는 API")
     ResponseEntity<SuccessResponse<UserFilterDetailResponseDto>> getUserFilter(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal long userId
     );
 
     @Operation(summary = "사용자 필터링 정보 수정 API", description = "사용자 필터링을 수정하는 API")
     ResponseEntity<SuccessResponse> updateUserFilter(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal long userId,
             @RequestBody UpdateUserFilterRequestDto requestDto
     );
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/ScrapSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/ScrapSwagger.java
@@ -15,20 +15,21 @@ public interface ScrapSwagger {
 
     @Operation(summary = "스크랩 추가", description = "사용자가 스크랩을 추가하는 API")
     ResponseEntity<SuccessResponse> createScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId, @RequestBody CreateScrapRequestDto request
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId,
+            @RequestBody CreateScrapRequestDto request
     );
 
     @Operation(summary = "스크랩 취소", description = "사용자가 스크랩을 취소하는 API")
     ResponseEntity<SuccessResponse> deleteScrap(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long internshipAnnouncementId
+            @AuthenticationPrincipal long userId,
+            @PathVariable long internshipAnnouncementId
     );
 
     @Operation(summary = "스크랩 수정", description = "사용자가 스크랩 색상을 수정하는 API")
     public ResponseEntity<SuccessResponse> updateScrapColor(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long scrapId,
+            @AuthenticationPrincipal long userId,
+            @PathVariable long scrapId,
             @RequestBody UpdateScrapRequestDto request
     );
 

--- a/src/main/java/org/terning/terningserver/domain/enums/Color.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Color.java
@@ -4,6 +4,10 @@ package org.terning.terningserver.domain.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Getter
 public enum Color {
@@ -22,7 +26,16 @@ public enum Color {
     private final String name;
     private final String value;
 
+    private static final Map<String, Color> colorMap =
+            Arrays.stream(Color.values())
+                    .collect(Collectors.toMap(Color::getName, color -> color));
+
     public String getColorValue() {
         return "#" + value;
     }
+
+    public static Color findByName(String name) {
+        return colorMap.get(name);
+    }
+
 }

--- a/src/main/java/org/terning/terningserver/domain/enums/Color.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Color.java
@@ -3,10 +3,14 @@ package org.terning.terningserver.domain.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.terning.terningserver.exception.CustomException;
+import org.terning.terningserver.exception.enums.ErrorMessage;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.terning.terningserver.exception.enums.ErrorMessage.INVALID_SCRAP_COLOR;
 
 @RequiredArgsConstructor
 @Getter
@@ -35,7 +39,11 @@ public enum Color {
     }
 
     public static Color findByName(String name) {
-        return colorMap.get(name);
+        Color color = colorMap.get(name);
+        if (color == null) {
+            throw new CustomException(INVALID_SCRAP_COLOR);
+        }
+        return color;
     }
 
 }

--- a/src/main/java/org/terning/terningserver/domain/enums/Grade.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/Grade.java
@@ -6,17 +6,17 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Grade {
-    FRESHMAN(0, "1학년"),
-    SOPHOMORE(1, "2학년"),
-    JUNIOR(2, "3학년"),
-    SENIOR(3, "4학년");
+    FRESHMAN("freshman", "1학년"),
+    SOPHOMORE("sophomore", "2학년"),
+    JUNIOR("junior", "3학년"),
+    SENIOR("senior", "4학년");
 
-    private final int key;
+    private final String key;
     private final String value;
     
-    public static Grade fromKey(int key){
+    public static Grade fromKey(String key){
         for(Grade grade : Grade.values()){
-            if(grade.key == key){
+            if(grade.key.equals(key)){
                 return grade;
             }
         }

--- a/src/main/java/org/terning/terningserver/domain/enums/WorkingPeriod.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/WorkingPeriod.java
@@ -7,16 +7,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum WorkingPeriod {
-    OPTION1(0, "1개월 ~ 3개월"),
-    OPTION2(1, "4개월 ~ 6개월"),
-    OPTION3(2, "7개월 이상");
+    OPTION1("short", "1개월 ~ 3개월"),
+    OPTION2("middle", "4개월 ~ 6개월"),
+    OPTION3("long", "7개월 이상");
 
-    private final int key;
+    private final String key;
     private final String value;
 
-    public static WorkingPeriod fromKey(int key){
+    public static WorkingPeriod fromKey(String key){
         for(WorkingPeriod period : WorkingPeriod.values()){
-            if(period.key == key){
+            if(period.key.equals(key)){
                 return period;
             }
         }

--- a/src/main/java/org/terning/terningserver/dto/auth/request/SignUpFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/auth/request/SignUpFilterRequestDto.java
@@ -7,13 +7,13 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record SignUpFilterRequestDto(
-        int grade,
-        int workingPeriod,
+        String grade,
+        String workingPeriod,
         int startYear,
         int startMonth
 
 ) {
-    public static SignUpFilterRequestDto of(int grade, int workingPeriod, int startYear, int startMonth) {
+    public static SignUpFilterRequestDto of(String grade, String workingPeriod, int startYear, int startMonth) {
         return SignUpFilterRequestDto.builder()
                 .grade(grade)
                 .workingPeriod(workingPeriod)

--- a/src/main/java/org/terning/terningserver/dto/filter/request/UpdateUserFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/request/UpdateUserFilterRequestDto.java
@@ -1,8 +1,8 @@
 package org.terning.terningserver.dto.filter.request;
 
-public record UserFilterRequestDto(
-        int grade,
-        int workingPeriod,
+public record UpdateUserFilterRequestDto(
+        String grade,
+        String workingPeriod,
         int startYear,
         int startMonth
 ) {

--- a/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 import org.terning.terningserver.domain.Filter;
 
 @Builder
-public record UserFilterResponseDto(
-        Integer grade,
-        Integer workingPeriod,
+public record UserFilterDetailResponseDto(
+        String grade,
+        String workingPeriod,
         Integer startYear,
         Integer startMonth
 ) {
-    public static UserFilterResponseDto of(Filter userFilter) {
-        return UserFilterResponseDto.builder()
+    public static UserFilterDetailResponseDto of(Filter userFilter) {
+        return UserFilterDetailResponseDto.builder()
                 .grade(userFilter == null ? null : userFilter.getGrade().getKey())
                 .workingPeriod(userFilter == null ? null : userFilter.getWorkingPeriod().getKey())
                 .startYear(userFilter == null ? null : userFilter.getStartYear())

--- a/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
@@ -3,14 +3,16 @@ package org.terning.terningserver.dto.filter.response;
 import lombok.Builder;
 import org.terning.terningserver.domain.Filter;
 
-@Builder
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
 public record UserFilterDetailResponseDto(
         String grade,
         String workingPeriod,
         Integer startYear,
         Integer startMonth
 ) {
-    public static UserFilterDetailResponseDto of(Filter userFilter) {
+    public static UserFilterDetailResponseDto of(final Filter userFilter) {
         return UserFilterDetailResponseDto.builder()
                 .grade(userFilter == null ? null : userFilter.getGrade().getKey())
                 .workingPeriod(userFilter == null ? null : userFilter.getWorkingPeriod().getKey())

--- a/src/main/java/org/terning/terningserver/dto/internship_detail/InternshipDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/internship_detail/InternshipDetailResponseDto.java
@@ -8,39 +8,41 @@ import org.terning.terningserver.util.DateUtil;
 
 @Builder
 public record InternshipDetailResponseDto(
+        String companyImage,
         String dDay,
         String title,
-        String deadline,
         String workingPeriod,
-        String startDate,
+        boolean isScrapped,
+        String color,
+        String deadline,
+        String startYearMonth,
         int scrapCount,
         int viewCount,
         String company,
         String companyCategory,
-        String companyImage,
         String qualification,
         String jobType,
         String detail,
-        String url,
-        Long scrapId
+        String url
 ) {
-    public static InternshipDetailResponseDto of(InternshipAnnouncement announcement, Company company, Long scrapId) {
+    public static InternshipDetailResponseDto of(InternshipAnnouncement announcement, Company company, Long scrapId, String color) {
         return InternshipDetailResponseDto.builder()
+                .companyImage(company.getCompanyImage())
                 .dDay(DateUtil.convert(announcement.getDeadline()))
                 .title(announcement.getTitle())
-                .deadline(DateUtil.convertDeadline(announcement.getDeadline()))
                 .workingPeriod(announcement.getWorkingPeriod())
-                .startDate(announcement.getStartYear() + "년 " + announcement.getStartMonth() + "월")
+                .isScrapped(scrapId!=null)
+                .color(color)
+                .deadline(DateUtil.convertDeadline(announcement.getDeadline()))
+                .startYearMonth(announcement.getStartYear() + "년 " + announcement.getStartMonth() + "월")
                 .scrapCount(announcement.getScrapCount())
                 .viewCount(announcement.getViewCount())
                 .company(company.getCompanyInfo())
                 .companyCategory(company.getCompanyCategory().getValue())
-                .companyImage(company.getCompanyImage())
                 .qualification(announcement.getQualifications())
                 .jobType(announcement.getJobType())
                 .detail(announcement.getDetail())
                 .url(announcement.getUrl())
-                .scrapId(scrapId)
                 .build();
     }
 }

--- a/src/main/java/org/terning/terningserver/dto/internship_detail/InternshipDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/internship_detail/InternshipDetailResponseDto.java
@@ -3,10 +3,11 @@ package org.terning.terningserver.dto.internship_detail;
 import lombok.Builder;
 import org.terning.terningserver.domain.Company;
 import org.terning.terningserver.domain.InternshipAnnouncement;
-import org.terning.terningserver.domain.Scrap;
 import org.terning.terningserver.util.DateUtil;
 
-@Builder
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
 public record InternshipDetailResponseDto(
         String companyImage,
         String dDay,
@@ -25,7 +26,12 @@ public record InternshipDetailResponseDto(
         String detail,
         String url
 ) {
-    public static InternshipDetailResponseDto of(InternshipAnnouncement announcement, Company company, Long scrapId, String color) {
+    public static InternshipDetailResponseDto of(
+            final InternshipAnnouncement announcement,
+            final Company company,
+            final Long scrapId,
+            final String color
+    ) {
         return InternshipDetailResponseDto.builder()
                 .companyImage(company.getCompanyImage())
                 .dDay(DateUtil.convert(announcement.getDeadline()))

--- a/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/search/response/SearchResultResponseDto.java
@@ -6,44 +6,52 @@ import org.terning.terningserver.util.DateUtil;
 
 import java.util.List;
 
+import static lombok.AccessLevel.PRIVATE;
+
 public record SearchResultResponseDto(
         int totalPages,
+        long totalCount,
         Boolean hasNext,
         List<SearchAnnouncementResponse> announcements
 ) {
-    @Builder
+    @Builder(access = PRIVATE)
     public record SearchAnnouncementResponse(
-            Long internshipAnnouncementId,
-            Long scrapId,
-            String dDay,
-            String deadline,
+            long internshipAnnouncementId,
             String companyImage,
+            String dDay,
             String title,
             String workingPeriod,
-            String startYearMonth,
-            String color
+            boolean isScrapped,
+            String color,
+            String deadline,
+            String startYearMonth
 
     ) {
-        public static SearchAnnouncementResponse from(final InternshipAnnouncement announcement, final Long scrapId, final String color) {
-            String startYearMonth = announcement.getStartYear() + "년 " + announcement.getStartMonth() + "월";
-            String deadline = DateUtil.convertDeadline(announcement.getDeadline());
-
+        public static SearchAnnouncementResponse from(
+                final InternshipAnnouncement announcement,
+                final Long scrapId,
+                final String color
+        ) {
             return SearchAnnouncementResponse.builder()
                     .internshipAnnouncementId(announcement.getId())
-                    .scrapId(scrapId)
-                    .dDay(DateUtil.convert(announcement.getDeadline()))
-                    .deadline(deadline)
                     .companyImage(announcement.getCompany().getCompanyImage())
+                    .dDay(DateUtil.convert(announcement.getDeadline()))
                     .title(announcement.getTitle())
                     .workingPeriod(announcement.getWorkingPeriod())
-                    .startYearMonth(startYearMonth)
+                    .isScrapped(scrapId!=null)
                     .color(color)
-//                    .isScrapped(isScrapped)
+                    .deadline(DateUtil.convertDeadline(announcement.getDeadline()))
+                    .startYearMonth(announcement.getStartYear() + "년 " + announcement.getStartMonth() + "월")
                     .build();
         }
     }
-    public static SearchResultResponseDto of(int totalPages, Boolean hasNext, List<SearchAnnouncementResponse> announcements) {
-        return new SearchResultResponseDto(totalPages, hasNext, announcements);
+    public static SearchResultResponseDto of(
+            final int totalPages,
+            final long totalCount,
+            final Boolean hasNext,
+            final List<SearchAnnouncementResponse> announcements
+    ) {
+        return new SearchResultResponseDto(totalPages, totalCount, hasNext, announcements);
     }
 
 }

--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -25,6 +25,7 @@ public enum ErrorMessage {
 
     // 스크랩
     EXISTS_SCRAP_ALREADY(400, "이미 스크랩했습니다."),
+    INVALID_SCRAP_COLOR(401, "유효하지 않은 스크랩 색상입니다."),
 
     // 로그 아웃
     FAILED_SIGN_OUT(404, "로그아웃에 실패하였습니다"),

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -77,8 +77,10 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .where(contentLike(keyword))
                 .fetchOne();
 
+        // 인턴공고가 없을 경우, 즉 count가 null일 경우 0L을 기본값으로 설정
+        long announcementCount = (count != null) ? count : 0L;
 
-        return new PageImpl<>(internshipAnnouncements, pageable, count);
+        return new PageImpl<>(internshipAnnouncements, pageable, announcementCount);
     }
 
     private BooleanExpression contentLike(String keyword) {

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
@@ -12,8 +12,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
 
     Optional<Scrap> findByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
 
-//    List<Scrap> findByUserIdAndInternshipAnnouncement_Deadline(Long userId, LocalDate deadline);
-
     void deleteByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
 
     List<Scrap> findByUserIdAndInternshipAnnouncement_DeadlineBetween(Long userId, LocalDate start, LocalDate end);

--- a/src/main/java/org/terning/terningserver/service/FilterService.java
+++ b/src/main/java/org/terning/terningserver/service/FilterService.java
@@ -1,11 +1,11 @@
 package org.terning.terningserver.service;
 
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 
 public interface FilterService {
 
     UserFilterResponseDto getUserFilter(Long userId);
 
-    void updateUserFilter(UserFilterRequestDto responseDto, Long userId);
+    void updateUserFilter(UpdateUserFilterRequestDto responseDto, Long userId);
 }

--- a/src/main/java/org/terning/terningserver/service/FilterService.java
+++ b/src/main/java/org/terning/terningserver/service/FilterService.java
@@ -1,11 +1,11 @@
 package org.terning.terningserver.service;
 
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 
 public interface FilterService {
 
-    UserFilterResponseDto getUserFilter(Long userId);
+    UserFilterDetailResponseDto getUserFilter(Long userId);
 
     void updateUserFilter(UpdateUserFilterRequestDto responseDto, Long userId);
 }

--- a/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
@@ -8,7 +8,7 @@ import org.terning.terningserver.domain.Filter;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
-import org.terning.terningserver.dto.filter.request.UserFilterRequestDto;
+import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.repository.filter.FilterRepository;
@@ -31,7 +31,7 @@ public class FilterServiceImpl implements FilterService {
 
     @Override
     @Transactional
-    public void updateUserFilter(UserFilterRequestDto responseDto, Long userId) {
+    public void updateUserFilter(UpdateUserFilterRequestDto responseDto, Long userId) {
         User user = findUser(userId);
         Filter filter = user.getFilter();
         if(filter != null){

--- a/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
@@ -9,7 +9,7 @@ import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
-import org.terning.terningserver.dto.filter.response.UserFilterResponseDto;
+import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.repository.filter.FilterRepository;
 import org.terning.terningserver.repository.user.UserRepository;
@@ -25,8 +25,8 @@ public class FilterServiceImpl implements FilterService {
     private final FilterRepository filterRepository;
 
     @Override
-    public UserFilterResponseDto getUserFilter(Long userId) {
-       return UserFilterResponseDto.of(findUser(userId).getFilter());
+    public UserFilterDetailResponseDto getUserFilter(Long userId) {
+       return UserFilterDetailResponseDto.of(findUser(userId).getFilter());
     }
 
     @Override

--- a/src/main/java/org/terning/terningserver/service/InternshipDetailService.java
+++ b/src/main/java/org/terning/terningserver/service/InternshipDetailService.java
@@ -5,5 +5,5 @@ import org.terning.terningserver.dto.internship_detail.InternshipDetailResponseD
 
 public interface InternshipDetailService {
 
-    InternshipDetailResponseDto getInternshipDetail(Long internshipAnnouncementId, Long userId);
+    InternshipDetailResponseDto getInternshipDetail(long internshipAnnouncementId, long userId);
 }

--- a/src/main/java/org/terning/terningserver/service/InternshipDetailServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/InternshipDetailServiceImpl.java
@@ -26,19 +26,18 @@ public class InternshipDetailServiceImpl implements InternshipDetailService {
         InternshipAnnouncement announcement = internshipRepository.findById(internshipAnnouncementId)
                 .orElseThrow(() -> new CustomException(ErrorMessage.NOT_FOUND_INTERN_EXCEPTION));
 
-
         announcement.updateViewCount();
         Optional<Scrap> scrap = scrapRepository.findByInternshipAnnouncementIdAndUserId(announcement.getId(), userId);
 
         if (scrap.isPresent()) {
             return InternshipDetailResponseDto.of(
                     announcement, announcement.getCompany(),
-                    scrapRepository.findByInternshipAnnouncementIdAndUserId(announcement.getId(), userId).get().getId()
+                    scrap.get().getId(), scrap.get().getColor().getColorValue()
             );
         } else {
             return InternshipDetailResponseDto.of(
                     announcement, announcement.getCompany(),
-                    null
+                    null, null
             );
         }
     }

--- a/src/main/java/org/terning/terningserver/service/InternshipDetailServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/InternshipDetailServiceImpl.java
@@ -22,7 +22,7 @@ public class InternshipDetailServiceImpl implements InternshipDetailService {
 
     @Override
     @Transactional
-    public InternshipDetailResponseDto getInternshipDetail(Long internshipAnnouncementId, Long userId) {
+    public InternshipDetailResponseDto getInternshipDetail(long internshipAnnouncementId, long userId) {
         InternshipAnnouncement announcement = internshipRepository.findById(internshipAnnouncementId)
                 .orElseThrow(() -> new CustomException(ErrorMessage.NOT_FOUND_INTERN_EXCEPTION));
 

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -19,6 +19,7 @@ import org.terning.terningserver.repository.internship_announcement.InternshipRe
 import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
 import org.terning.terningserver.util.DateUtil;
+import org.terning.terningserver.util.LogExecutionTime;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -148,7 +149,7 @@ public class ScrapServiceImpl implements ScrapService {
     public void updateScrapColor(Long internshipAnnouncementId, UpdateScrapRequestDto request, Long userId) {
         Scrap scrap = findScrap(internshipAnnouncementId, userId);
         verifyScrapOwner(scrap, userId);
-        scrap.updateColor(findColor(request.color()));
+        scrap.updateColor(Color.findByName(request.color()));
     }
 
     //토큰으로 찾은(요청한) User와 스크랩한 User가 일치한지 여부 검증하는 메서드

--- a/src/main/java/org/terning/terningserver/service/SearchServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/SearchServiceImpl.java
@@ -43,7 +43,7 @@ public class SearchServiceImpl implements SearchService {
 
         List<InternshipAnnouncement> announcements = pageAnnouncements.getContent();
 
-        List<SearchResultResponseDto.SearchAnnouncementResponse> searchAnnouncementResponses = new ArrayList<>();
+        List<SearchResultResponseDto.SearchAnnouncementResponse> searchAnnouncementResponses;
 
         List<Scrap> scraps = scrapRepository.findAllByInternshipAndUserId(announcements, userId);
 
@@ -57,12 +57,16 @@ public class SearchServiceImpl implements SearchService {
         searchAnnouncementResponses = announcements.stream()
                 .map(a -> {
                     Scrap scrap = scrapMap.get(a.getId());
-                    return SearchResultResponseDto.SearchAnnouncementResponse.from(a, scrap != null ? scrap.getId() : null, scrap != null ? scrap.getColor().getColorValue() : null);
+                    return SearchResultResponseDto.SearchAnnouncementResponse.from(
+                            a, scrap != null ? scrap.getId() : null,
+                            scrap != null ? scrap.getColor().getColorValue() : null
+                    );
                 })
                 .toList();
 
         return new SearchResultResponseDto(
                 pageAnnouncements.getTotalPages(),
+                pageAnnouncements.getTotalElements(),
                 pageAnnouncements.hasNext(),
                 searchAnnouncementResponses
         );

--- a/src/main/java/org/terning/terningserver/util/LogAspect.java
+++ b/src/main/java/org/terning/terningserver/util/LogAspect.java
@@ -1,0 +1,37 @@
+package org.terning.terningserver.util;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.hibernate.type.descriptor.java.ObjectJavaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class LogAspect {
+
+    Logger logger = LoggerFactory.getLogger(LogAspect.class);
+
+    @Around("@annotation(LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        //@LogExecutionTime이 붙어있는 타켓 메소드의 성능 측정
+        Object proceed = joinPoint.proceed();
+
+        stopWatch.stop();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        logger.info("실행한 메소드: " + signature.getMethod().getName());
+        logger.info("수행 시간: " + stopWatch.getTotalTimeMillis() + "ms");
+
+        return proceed;
+    }
+}

--- a/src/main/java/org/terning/terningserver/util/LogExecutionTime.java
+++ b/src/main/java/org/terning/terningserver/util/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package org.terning.terningserver.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}


### PR DESCRIPTION
# 📄 Work Description
- 공고 상세 정보 및 검색 결과 화면 response body 수정

# ⚙️ ISSUE
- closed #129


# 📷 Screenshot
 - 공고 상세 페이지 API
![image](https://github.com/user-attachments/assets/102b4ed0-e09c-40e7-b08a-7081b7905f68)

<br/>

- 검색 결과 화면 API
![image](https://github.com/user-attachments/assets/142ccf3f-1079-41ef-981b-5a7fc91eb5c2)


# 💬 To Reviewers
바뀐 수정사항은 아래와 같습니다!!
> 공고 상세 정보 API 수정사항
- startDate(근무시작일) 필드명을 startYearMonth 로 수정(다른 API와의 통일성을 위해)
- color 필드 추가
- 스크랩 여부(기존 scrapId > isScrapped, 스크랩 추가 & 취소 & 색상 수정시 모두 기존 scrapId에서 internshipAnnouncementId로 통신하는 것으로 변경되었으므로)

<br/>

> 검색 결과 화면 API
- totalCount 필드 추가 (전체 데이터 개수)
- 스크랩 여부(기존 scrapId > isScrapped, 스크랩 추가 & 취소 & 색상 수정시 모두 기존 scrapId에서 internshipAnnouncementId로 통신하는 것으로 변경되었으므로)

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
