### PR TITLE
[♻️ refactor] 소셜로그인 > Swagger와 API 문서 간 정보 불일치 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/AuthController.java
+++ b/src/main/java/org/terning/terningserver/controller/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController implements AuthSwagger {
 
     @PostMapping("/sign-up")
     public ResponseEntity<SuccessResponse<SignUpResponseDto>> signUp(
-            @RequestHeader("authId") String authId,
+            @RequestHeader("Authorization") String authId,
             @RequestBody SignUpRequestDto request
     ) {
 

--- a/src/main/java/org/terning/terningserver/controller/swagger/AuthSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/AuthSwagger.java
@@ -1,6 +1,7 @@
 package org.terning.terningserver.controller.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,23 +21,27 @@ public interface AuthSwagger {
 
     @Operation(summary = "소셜 로그인", description = "AuthType에 맞는 소셜 로그인 API")
     ResponseEntity<SuccessResponse<SignInResponseDto>> signIn(
+            @Parameter(name = "Authorization", description = "", example = "authAccessToken")
             @RequestHeader("Authorization") String authAccessToken,
             @RequestBody SignInRequestDto request
     );
 
     @Operation(summary = "토큰 재발급", description = "토큰 재발급 API")
     ResponseEntity<SuccessResponse<AccessTokenGetResponseDto>> reissueToken(
+            @Parameter(name = "Authorization", description = "", example = "refreshToken")
             @RequestHeader("Authorization") String refreshToken
     );
 
     @Operation(summary = "사용자 필터링 정보 생성", description = "사용자 필터링 정보 생성 API")
     ResponseEntity<SuccessResponse<SignUpFilterResponseDto>> filter(
+            @Parameter(name = "User-Id", description = "", example = "userId")
             @RequestHeader("User-Id") Long userId,
             @RequestBody SignUpFilterRequestDto request
     );
 
     @Operation(summary = "회원가입", description = "회원가입 API")
     ResponseEntity<SuccessResponse<SignUpResponseDto>> signUp(
+            @Parameter(name = "Authorization", description = "", example = "authId")
             @RequestHeader("authId") String authId,
             @RequestBody SignUpRequestDto request
     );


### PR DESCRIPTION
# 📄 Work Description
- 소셜 로그인, 토큰 재발급, 필터링 정보 생성, 회원가입 API에 대한 Swagger 주석 추가 및 설명 보완
- API 문서와 Swagger 설명 간의 불일치 문제 해결

# ⚙️ ISSUE
- closed #134 

# 📷 Screenshot
## 토큰 재발급 Before
![스크린샷 2024-09-14 오전 8 56 40](https://github.com/user-attachments/assets/17700edc-6c55-45ca-bb7e-8d44a23611a5)

## 토큰 재발급 After
![스크린샷 2024-09-14 오전 8 55 48](https://github.com/user-attachments/assets/50e61d2b-1dcf-4021-8d99-60d710094d2d)

## 소셜 로그인 Before
![스크린샷 2024-09-14 오전 9 00 39](https://github.com/user-attachments/assets/167249fd-2eb0-4088-89a0-12ce96aa4970)

## 소셜 로그인 After
![스크린샷 2024-09-14 오전 8 55 58](https://github.com/user-attachments/assets/d0fb1d1a-f0dc-48f0-ac38-d7742d396859)

# 💬 To Reviewers
- Swagger 설명과 API 문서 간의 차이를 중점적으로 봐주시면 감사하겠습니다. 추가로 필요한 설명이나 수정 사항이 있다면 코멘트 부탁드립니다.
- 기존 방식에서는 name과 description 박스를 개별적으로 컨트롤할 수 없었습니다. 이러한 상황에서, 클라이언트가 박스 안의 값을 보고 더 쉽게 이해할 수 있도록 개선 방향을 잡았고, 그 결과 description에 'Example:'이 표시되더라도 example 값을 사용하였습니다.

# 🔗 Reference
- [Swagger 공식 문서](https://swagger.io/docs/)
- [Springfox Swagger 설정 관련 문서](https://springfox.github.io/springfox/docs/current/)