### PR TITLE
[♻️ refactor] 홈 > 곧 마감되는 관심공고 : 분기 처리를 위한 데이터 형식 추가

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -13,8 +13,7 @@ import org.terning.terningserver.service.ScrapService;
 
 import java.util.List;
 
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_ANNOUNCEMENTS;
-import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_UPCOMING_ANNOUNCEMENTS;
+import static org.terning.terningserver.exception.enums.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,6 +44,13 @@ public class HomeController implements HomeSwagger {
         List<UpcomingScrapResponseDto.ScrapDetail> scrapList = scrapService.getUpcomingScrap(userId);
 
         UpcomingScrapResponseDto responseDto = new UpcomingScrapResponseDto(hasScrapped, scrapList);
-        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS, responseDto));
+
+        if(!hasScrapped){
+            return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS_NO_SCRAP, responseDto));
+        } else if (scrapList.isEmpty()) {
+            return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS_EMPTY_LIST, responseDto));
+        } else {
+            return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS, responseDto));
+        }
     }
 }

--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -41,8 +41,10 @@ public class HomeController implements HomeSwagger {
             @AuthenticationPrincipal Long userId
     ){
 
-        List<UpcomingScrapResponseDto> scrapList = scrapService.getUpcomingScrap(userId);
+        boolean hasScrapped = scrapService.hasUserScrapped(userId);
+        List<UpcomingScrapResponseDto.ScrapDetail> scrapList = scrapService.getUpcomingScrap(userId);
 
-        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS, scrapList));
+        UpcomingScrapResponseDto responseDto = new UpcomingScrapResponseDto(hasScrapped, scrapList);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_UPCOMING_ANNOUNCEMENTS, responseDto));
     }
 }

--- a/src/main/java/org/terning/terningserver/dto/user/response/UpcomingScrapResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/UpcomingScrapResponseDto.java
@@ -4,33 +4,41 @@ import lombok.Builder;
 import org.terning.terningserver.domain.Scrap;
 import org.terning.terningserver.util.DateUtil;
 
+import java.util.List;
+
 @Builder
 public record UpcomingScrapResponseDto(
-        Long internshipAnnouncementId,
-        String companyImage,
-        String dDay,
-        String title,
-        String workingPeriod,
-        boolean isScrapped,
-        String color,
-        String deadline,
-        String startYearMonth,
-        String companyInfo
+        boolean hasScrapped,
+        List<ScrapDetail> scraps
 ) {
-    public static UpcomingScrapResponseDto of(final Scrap scrap){
-        String startYearMonth = scrap.getInternshipAnnouncement().getStartYear() + "년 " + scrap.getInternshipAnnouncement().getStartMonth() + "월";
+    @Builder
+    public record ScrapDetail(
+            Long internshipAnnouncementId,
+            String companyImage,
+            String dDay,
+            String title,
+            String workingPeriod,
+            boolean isScrapped,
+            String color,
+            String deadline,
+            String startYearMonth,
+            String companyInfo
+    ) {
+        public static ScrapDetail of(final Scrap scrap) {
+            String startYearMonth = scrap.getInternshipAnnouncement().getStartYear() + "년 " + scrap.getInternshipAnnouncement().getStartMonth() + "월";
 
-        return UpcomingScrapResponseDto.builder()
-                .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
-                .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
-                .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
-                .title(scrap.getInternshipAnnouncement().getTitle())
-                .deadline(DateUtil.convertDeadline(scrap.getInternshipAnnouncement().getDeadline()))
-                .isScrapped(true) // 스크랩된 항목이므로 항상 true
-                .color(scrap.getColorToHexValue())
-                .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
-                .startYearMonth(startYearMonth)
-                .companyInfo(scrap.getInternshipAnnouncement().getCompany().getCompanyInfo())
-                .build();
+            return ScrapDetail.builder()
+                    .internshipAnnouncementId(scrap.getInternshipAnnouncement().getId())
+                    .companyImage(scrap.getInternshipAnnouncement().getCompany().getCompanyImage())
+                    .dDay(DateUtil.convert(scrap.getInternshipAnnouncement().getDeadline()))
+                    .title(scrap.getInternshipAnnouncement().getTitle())
+                    .deadline(DateUtil.convertDeadline(scrap.getInternshipAnnouncement().getDeadline()))
+                    .isScrapped(true) // 스크랩된 항목이므로 항상 true
+                    .color(scrap.getColorToHexValue())
+                    .workingPeriod(scrap.getInternshipAnnouncement().getWorkingPeriod())
+                    .startYearMonth(startYearMonth)
+                    .companyInfo(scrap.getInternshipAnnouncement().getCompany().getCompanyInfo())
+                    .build();
+        }
     }
 }

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -9,6 +9,8 @@ public enum SuccessMessage {
     // 홈 화면
     SUCCESS_GET_ANNOUNCEMENTS(200, "인턴 공고 불러오기를 성공했습니다"),
     SUCCESS_GET_UPCOMING_ANNOUNCEMENTS(200, "곧 마감인 인턴 공고 요청을 성공했습니다"),
+    SUCCESS_GET_UPCOMING_ANNOUNCEMENTS_NO_SCRAP(200, "아직 스크랩된 인턴 공고가 없어요!"),
+    SUCCESS_GET_UPCOMING_ANNOUNCEMENTS_EMPTY_LIST(200, "일주일 내에 마감인 공고가 없어요\n캘린더에서 스크랩한 공고 일정을 확인해 보세요"),
 
     // 소셜 로그인
     SUCCESS_SIGN_IN(200, "소셜 로그인에 성공하였습니다"),

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
@@ -14,7 +14,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
 
     void deleteByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
 
-    List<Scrap> findByUserIdAndInternshipAnnouncement_DeadlineBetween(Long userId, LocalDate start, LocalDate end);
+    boolean existsByUserId(Long userId);
 
 }
 

--- a/src/main/java/org/terning/terningserver/service/ScrapService.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapService.java
@@ -11,7 +11,9 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface ScrapService {
-    List<UpcomingScrapResponseDto> getUpcomingScrap(Long userId);
+
+    boolean hasUserScrapped(long userId);
+    List<UpcomingScrapResponseDto.ScrapDetail> getUpcomingScrap(long userId);
 
     void createScrap(Long internshipAnnouncementId, CreateScrapRequestDto request, Long userId);
 

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -39,11 +39,16 @@ public class ScrapServiceImpl implements ScrapService {
     private final UserRepository userRepository;
 
     @Override
-    public List<UpcomingScrapResponseDto> getUpcomingScrap(Long userId){
+    public boolean hasUserScrapped(long userId) {
+        return scrapRepository.existsByUserId(userId);
+    }
+
+    @Override
+    public List<UpcomingScrapResponseDto.ScrapDetail> getUpcomingScrap(long userId){
         LocalDate today = LocalDate.now();
         LocalDate oneWeekFromToday = today.plusDays(7);
         return scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(userId, today, oneWeekFromToday).stream()
-                .map(UpcomingScrapResponseDto::of)
+                .map(UpcomingScrapResponseDto.ScrapDetail::of)
                 .toList();
     }
 


### PR DESCRIPTION
# 📄 Work Description
- 현재 곧 마감되는 공고 UI의 응답 흐름은 다음과 같습니다.
스크랩된 공고 X, 곧 마감 공고 X -> "아직 스크랩된 인턴 공고가 없어요!"
스크랩된 공고 O, 곧 마감 공고 X -> "공고 마감 일정 확인하기"
스크랩된 공고 O, 곧 마감 공고 O -> 공고 정보 보여주기

현재는 이렇게 구성되어 있으나, 분기처리를 위해 유저가 스크랩한 공고가 있는지를 알아야 하는데 곧 마감 공고 API에서는 알 수가 없는 문제가 있습니다.

곧 마감 공고 API에 유저가 스크랩한 공고가 있는지 여부(hasScrapped)를 response에 추가하여

스크랩을 했으나 곧 마감되는 공고가 없는 것인지와
스크랩한 공고가 아예없는 것인지 각각에 대한 분기처리를 명확히 구분했습니다!

# ⚙️ ISSUE
- closed #137 


# 📷 Screenshot
### 스크랩된 공고 X, 곧 마감 공고 X -> "아직 스크랩된 인턴 공고가 없어요!" (hasScrapped = false)
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/ca3e7343-c7b5-446c-ba25-a2e24eda633b">


### 스크랩된 공고 O, 곧 마감 공고 X -> "일주일 내에 마감인 공고가 없어요\n캘린더에서 스크랩한 공고 일정을 확인해 보세요" (hasScrapped = true)
<img width="1415" alt="image" src="https://github.com/user-attachments/assets/bf4ee521-50fb-48b1-bea1-51f551fb2173">


### 스크랩된 공고 O, 곧 마감 공고 O -> "곧 마감인 인턴 공고 요청을 성공했습니다" (hasScrapped = true)
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/37c2b038-2551-4e22-86a6-c455bdc66ea7">
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/09f68255-c635-415e-aa40-d45624f59bb6">


# 💬 To Reviewers


# 🔗 Reference
