### PR TITLE
[🔨fix] 회원가입 관련 상태 코드 수정 및 예외 처리 변경

### DIFF
--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -16,8 +16,8 @@ public enum ErrorMessage {
     UNAUTHORIZED_JWT_EXCEPTION(401, "유효하지 않은 토큰입니다"),
 
     // 회원가입
-    FAILED_SIGN_UP(401, "회원가입에 실패하였습니다"),
-    EXISTS_USER_ALREADY(401, "이미 존재하는 유저입니다"),
+    FAILED_SIGN_UP(400, "회원가입에 실패하였습니다"),
+    EXISTS_USER_ALREADY(409, "이미 존재하는 유저입니다"),
 
     // 사용자 필터링 정보 생성
     FAILED_SIGN_UP_USER_FILTER_CREATION(404, "사용자 필터 생성에 실패하였습니다"),

--- a/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
@@ -190,7 +190,7 @@ public class AuthServiceImpl implements AuthService {
 
     private User findUserByRefreshToken(String refreshToken) {
         return userRepository.findByRefreshToken(getTokenFromBearerString(refreshToken))
-                .orElseThrow(() -> new CustomException(INVALID_USER));
+                .orElseThrow(() -> new CustomException(FAILED_TOKEN_REISSUE));
     }
 
 


### PR DESCRIPTION
# 📄 Work Description
- 회원가입 관련 상태 코드를 더 적절하게 수정했습니다.
  - 회원가입 실패 시 `401 Unauthorized`에서 `400 Bad Request`로 변경.
  - 이미 존재하는 유저일 경우 `401 Unauthorized`에서 `409 Conflict`로 변경.
- `AuthServiceImpl`에서 잘못된 리프레시 토큰 사용 시 예외 처리를 `INVALID_USER`에서 `FAILED_TOKEN_REISSUE`로 수정.

# ⚙️ ISSUE
- closed #141

# 💬 To Reviewers
- 클라이언트 사이드에서 회원가입 관련 이슈가 있다고 해서 서버 로직을 확인했지만, 서버 로직에는 문제가 없었습니다. 
- 클라이언트 로직을 함께 살펴보고 문제를 해결하였으며, 그 과정에서 상태 코드 수정 요청이 있었습니다. 
- 회원가입 실패 및 중복 유저 관련 상태 코드를 더 명확하게 하기 위해 수정했으니, 코드 변경 사항을 확인해 주시기 바랍니다.
- 상태 코드 변경이 서버와 클라이언트 간 통신에 문제가 없도록 추가적인 검토를 부탁드립니다.

# 🔗 Reference
- [HTTP 상태 코드 관련 문서](https://developer.mozilla.org/ko/docs/Web/HTTP/Status)
