### PR TITLE
[🔨 fix/#147] 소셜 로그인 > authId 전처리

### DIFF
--- a/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
@@ -56,7 +56,9 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     public SignUpResponseDto signUp(String authId, SignUpRequestDto request) {
-        SignUpWithAuthIdRequestDto requestDto = createSignUpRequestDto(authId, request);
+        String tokenWithoutBearer = authId.replace("Bearer ", "").trim();
+
+        SignUpWithAuthIdRequestDto requestDto = createSignUpRequestDto(tokenWithoutBearer, request);
 
         User user = createUser(requestDto);
 


### PR DESCRIPTION
# 📄 Work Description
- 회원가입 시 authId에서 'Bearer ' 문자열을 제거하는 로직을 추가했습니다.
- 로그아웃 후 재로그인 시 토큰이 제대로 반환되지 않는 문제가 있었는데, 이 또한 'Bearer ' 문자열로 인해 발생한 문제임을 확인했습니다.
- authId를 기준으로 사용자를 찾지 못해 신규 회원으로 잘못 인식된 문제도 함께 해결했습니다.

# ⚙️ ISSUE
- closed #147 

# 📷 Screens
![스크린샷 2024-09-26 오후 12 08 02](https://github.com/user-attachments/assets/52687ee6-0721-48ee-9c1f-e105d23c684a)


# 💬 To Reviewers
- authId 사용 시 'Bearer ' 문자열을 제거하도록 변경했습니다. 이로 인해 발생했던 로그인 문제도 해결된 상태입니다. 다른 토큰 처리 로직과 충돌 가능성이 없는지 한 번 더 검토 부탁드립니다.

# 🔗 Reference
- JWT 토큰 처리 관련 참고 자료: [[jwt.io](https://jwt.io/introduction)]
