### PR TITLE
[♻️ refactor/#143]: 불필요한 중복 에러 메시지 제거 및 코드 정리

### DIFF
--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -15,10 +15,6 @@ public enum ErrorMessage {
     FAILED_TOKEN_REISSUE(404, "토큰 재발급에 실패하였습니다"),
     UNAUTHORIZED_JWT_EXCEPTION(401, "유효하지 않은 토큰입니다"),
 
-    // 회원가입
-    FAILED_SIGN_UP(400, "회원가입에 실패하였습니다"),
-    EXISTS_USER_ALREADY(409, "이미 존재하는 유저입니다"),
-
     // 사용자 필터링 정보 생성
     FAILED_SIGN_UP_USER_FILTER_CREATION(404, "사용자 필터 생성에 실패하였습니다"),
     FAILED_SIGN_UP_USER_FILTER_ASSIGNMENT(404, "사용자 필터 연결에 실패하였습니다"),
@@ -32,7 +28,7 @@ public enum ErrorMessage {
     FAILED_REFRESH_TOKEN_RESET(400, "리프레쉬 토큰 초기화에 실패하였습니다"),
 
     // 계정 탈퇴
-    FAILED_WITHDRAW(404, "계정 탈퇴에 실패하였습니다"),
+    FAILED_WITHDRAW(400, "계정 탈퇴에 실패하였습니다"),
 
     // 마이페이지
     INVALID_PROFILE_IMAGE(404, "유효하지 않은 프로필 이미지 입니다."),


### PR DESCRIPTION
# 📄 Work Description
- 불필요한 중복 에러 메시지 제거 및 코드 정리
- 계정 탈퇴 시 잘못된 404 에러 코드를 400 에러 코드로 수정

# ⚙️ ISSUE
- closed #143

# 💬 To Reviewers
- 계정 탈퇴 실패 관련 에러 코드 변경 사항을 검토 부탁드립니다.
- 이외 다른 에러 메시지 중에서도 불필요한 중복이 있을 수 있으니 확인 부탁드립니다.
- 현재 회원가입을 할 때 클라이언트 측에서만 검증 로직을 처리하고 서버에서는 따로 검증을 하지 않고 있는데, 이번 기회에 서버에서도 검증 로직을 도입하려고 합니다. 이에 대한 의견을 듣고 싶습니다.
- 또한, 기존의 소셜 로그인 상태 코드들에 대해서도 전반적인 의견을 부탁드립니다.

# 🔗 Reference
- [HTTP 응답 상태 코드](https://developer.mozilla.org/ko/docs/Web/HTTP/Status)
