### PR TITLE
[✨ feat/#144] Discord 회원가입 알림 구현

### DIFF
--- a/src/main/java/org/terning/terningserver/repository/user/UserRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/user/UserRepository.java
@@ -14,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByAuthIdAndAuthType(String authId, AuthType authType);
 
+
 }

--- a/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
@@ -43,6 +43,7 @@ public class AuthServiceImpl implements AuthService {
     private final ValueConfig valueConfig;
     private final UserRepository userRepository;
     private final FilterRepository filterRepository;
+    private final WebhookService webhookService;
 
     @Override
     @Transactional
@@ -61,6 +62,8 @@ public class AuthServiceImpl implements AuthService {
         User user = createUser(requestDto);
 
         Token token = getFullToken(user);
+
+        webhookService.sendDiscordNotification(user); // 디스코드에 회원가입 알림 전송
 
         return createSignUpResponseDto(token, user);
     }

--- a/src/main/java/org/terning/terningserver/service/WebhookService.java
+++ b/src/main/java/org/terning/terningserver/service/WebhookService.java
@@ -1,0 +1,54 @@
+package org.terning.terningserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.terning.terningserver.domain.User;
+import org.terning.terningserver.repository.user.UserRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class WebhookService {
+
+    // 디스코드 웹훅 URL 주입
+    @Value("${discord.webhook.url}")
+    private String discordWebhookUrl;
+
+    private final UserRepository userRepository;
+
+    // 알림을 보내는 메서드
+    public void sendDiscordNotification(User user) {
+
+        // REST 요청을 처리하기 위한 RestTemplate 객체 생성
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 회원 수를 기존 DB에서 조회하여 총 회원 수 계산
+        Long totalMembers = userRepository.count();
+
+        // 알림 메시지 생성
+        String message = String.format("가입자명 : %s\n[%d] 번째 유저가 회원가입했습니다!", user.getName(), totalMembers);
+
+        // HTTP 요청을 위한 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // HTTP 요청 바디에 전송할 메시지 설정
+        Map<String, String> body = new HashMap<>();
+        body.put("content", message);
+
+        // HTTP 요청 엔터티 생성
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+        // 디스코드 웹훅 URL로 POST 요청을 보내어 알림 전송
+        restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- [✨feat/#144] Discord 회원가입 알림 구현
- `Discord`의 웹 훅 기능을 연동하여 유저가 회원가입 시 디스코드에 알림 메시지가 발송되도록 구현하여, 현재 유저가 얼마나 가입했는지 직관적으로 확인할 수 있는 기능을 구현하였습니다.

# ⚙️ ISSUE
- closed #144 


# 📷 Screenshot
 - Discord 알림 예시
<img width="962" alt="image" src="https://github.com/user-attachments/assets/010ea154-d435-45bf-87ac-7cea28886951">


# 🔗 Reference
[참고링크](https://velog.io/@hanni/Spring-Boot3-%EC%83%88%EB%A1%9C%EC%9A%B4-%EB%A9%A4%EB%B2%84%EA%B0%80-%EA%B0%80%EC%9E%85%ED%96%88%EC%8A%B5%EB%8B%88%EB%8B%A4-%EB%94%94%EC%8A%A4%EC%BD%94%EB%93%9C-%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EC%95%8C%EB%A6%BC-%EC%9B%B9%ED%9B%85-%EB%A7%8C%EB%93%A4%EA%B8%B0)
