### PR TITLE
[🔨 fix/#140] 검색화면 totalPages, totalCount 데이터 부정확한 오류 수정 

### DIFF
--- a/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
+++ b/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
@@ -4,12 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.terning.terningserver.domain.common.BaseTimeEntity;
-import org.terning.terningserver.domain.enums.Grade;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;

--- a/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
+++ b/src/main/java/org/terning/terningserver/domain/InternshipAnnouncement.java
@@ -48,7 +48,7 @@ public class InternshipAnnouncement extends BaseTimeEntity {
     @Column(nullable = false, length = 256)
     private String url;  // 인턴십 공고 URL
 
-    @OneToMany(mappedBy = "internshipAnnouncement")
+    @OneToMany(mappedBy = "internshipAnnouncement", cascade = CascadeType.ALL)
     private List<Scrap> scraps;
 
     @Embedded
@@ -65,9 +65,6 @@ public class InternshipAnnouncement extends BaseTimeEntity {
 
     @Column(nullable = false)
     private boolean isGraduating; // 졸업 예정 여부
-
-    @OneToMany(mappedBy = "internshipAnnouncement", cascade = CascadeType.ALL)
-    private List<Scrap> scrapList = new ArrayList<>(); //스크랩 리스트
 
     public void updateViewCount(){
         this.viewCount += 1;

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -65,7 +65,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
 
         List<InternshipAnnouncement> internshipAnnouncements = jpaQueryFactory
                 .selectFrom(internshipAnnouncement)
-                .leftJoin(internshipAnnouncement.scraps)
+                .leftJoin(internshipAnnouncement.scraps, scrap)
                 .where(contentLike(keyword))
                 .orderBy(sortAnnouncementsByDeadline().asc(), createOrderSpecifier(sortBy))
                 .offset(pageable.getOffset())
@@ -86,6 +86,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
 
     //정렬 조건(5가지, 채용 마감 이른 순, 짧은 근무 기간 순, 긴 근무 기간 순,
     private OrderSpecifier createOrderSpecifier(String sortBy) {
+        System.out.println("sortBy = " + sortBy);
         return switch (sortBy) {
             case "mostViewed" -> internshipAnnouncement.viewCount.desc();
             case "shortestDuration" -> getWorkingPeriodAsNumber().asc();

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -65,7 +66,6 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
 
         List<InternshipAnnouncement> internshipAnnouncements = jpaQueryFactory
                 .selectFrom(internshipAnnouncement)
-                .leftJoin(internshipAnnouncement.scraps, scrap)
                 .where(contentLike(keyword))
                 .orderBy(sortAnnouncementsByDeadline().asc(), createOrderSpecifier(sortBy))
                 .offset(pageable.getOffset())
@@ -76,6 +76,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .select(internshipAnnouncement.count())
                 .from(internshipAnnouncement)
                 .where(contentLike(keyword));
+
 
         return PageableExecutionUtils.getPage(internshipAnnouncements, pageable, count::fetchOne);
     }
@@ -101,7 +102,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     public List<InternshipAnnouncement> findFilteredInternships(User user, String sortBy, int startYear, int startMonth){
         return jpaQueryFactory
                 .selectFrom(internshipAnnouncement)
-                .leftJoin(internshipAnnouncement.scrapList, scrap).on(scrap.user.eq(user))
+                .leftJoin(internshipAnnouncement.scraps, scrap).on(scrap.user.eq(user))
                 .where(
                         getGraduatingFilter(user),
                         getWorkingPeriodFilter(user),


### PR DESCRIPTION
# 📄 Work Description
- 검색화면 totalPages, totalCount 데이터 부정확한 오류 수정 

# ⚙️ ISSUE
- closed #140 


# 📷 Screenshot
 - postman
<img width="1325" alt="스크린샷 2024-09-27 오후 8 44 35" src="https://github.com/user-attachments/assets/738cfbc2-f194-47c5-839b-1e73e64543de">
, 스웨거, 포스트맨 등


# 💬 To Reviewers
다시 돌아왔슴다.. 데이터 부정확한 문제가 해결되지 않아서 몇 시간 동안 삽질하였음니다.. 이번에는 원인을 제대로 찾은 것 같아요 ...

문제 원인은 아래와 같습니다.
> left join()으로 인한 데이터 중복

지난 번에 `fetchjoin()`이 내부적으로 `innerjoin()`으로 작동하여 데이터 중복이 있었다고 말씀드렸는데요! 이번에는 `leftjoin()`으로 인한 데이터 중복 문제가 있었습니다... `leftjoin()`은 데이터 중복 문제가 없는 줄 알았습니다..!

- `InternshipAnnouncement`와 `scrap` 테이블을 `internshipAnnounctmentId`를 기준으로 조인할 경우, 하나의 인턴공고는 다중의 사용자로부터 스크랩될 수 있기 때문에 조인했을 경우 아래 사진과 같이 중복 데이터가 생기게 됩니다..!

<img width="700" alt="스크린샷 2024-09-27 오후 8 48 22" src="https://github.com/user-attachments/assets/63bce776-9645-493d-ad9e-4b86582dbaf1">


# 🔗 Reference
https://neverfadeaway.tistory.com/20