### PR TITLE
[🔨fix/#160] 인턴 공고 검색 로직 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -94,7 +94,6 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
             keyword = keyword.replaceAll("\\s", "");
             return Expressions.stringTemplate("REPLACE(LOWER({0}), ' ', '')", internshipAnnouncement.title).contains(keyword);
         }
-//        return internshipAnnouncement.title.contains(keyword);
     }
 
     //정렬 조건(5가지, 채용 마감 이른 순, 짧은 근무 기간 순, 긴 근무 기간 순,

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -63,10 +63,11 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
 
     @Override
     public Page<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable) {
+        keyword = keyword.toLowerCase();
 
         List<InternshipAnnouncement> internshipAnnouncements = jpaQueryFactory
                 .selectFrom(internshipAnnouncement)
-                .where(contentLike(keyword))
+                .where(contentLike(keyword, isPureEnglish(keyword)))
                 .orderBy(sortAnnouncementsByDeadline().asc(), createOrderSpecifier(sortBy))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -75,14 +76,25 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
         JPAQuery<Long> count = jpaQueryFactory
                 .select(internshipAnnouncement.count())
                 .from(internshipAnnouncement)
-                .where(contentLike(keyword));
+                .where(contentLike(keyword, isPureEnglish(keyword)));
 
 
         return PageableExecutionUtils.getPage(internshipAnnouncements, pageable, count::fetchOne);
     }
 
-    private BooleanExpression contentLike(String keyword) {
-        return internshipAnnouncement.title.contains(keyword);
+    private boolean isPureEnglish(String summonerName) {
+        //공백은 무시
+        return summonerName.replaceAll("\\s", "").matches("^[a-zA-Z]+$");
+    }
+
+    private BooleanExpression contentLike(String keyword, boolean isPureEnglish) {
+        if(isPureEnglish) {
+            return Expressions.stringTemplate("LOWER({0})", internshipAnnouncement.title).contains(keyword);
+        } else {
+            keyword = keyword.replaceAll("\\s", "");
+            return Expressions.stringTemplate("REPLACE(LOWER({0}), ' ', '')", internshipAnnouncement.title).contains(keyword);
+        }
+//        return internshipAnnouncement.title.contains(keyword);
     }
 
     //정렬 조건(5가지, 채용 마감 이른 순, 짧은 근무 기간 순, 긴 근무 기간 순,


### PR DESCRIPTION
# 📄 Work Description
- 우선 PR이 늦어진 점 죄송함다..🙇‍♀️ 

# ⚙️ ISSUE
- closed #이슈번호


# 📷 Screenshot
 - 영어 대소문자 구분없이 공고 검색 가능
![image](https://github.com/user-attachments/assets/bea5538d-e05d-468d-b46b-14bd4ad4a097)

<br/>

- 한글 띄어쓰기 관계없이 공고 검색 가능
![image](https://github.com/user-attachments/assets/57f7ca91-88e6-414b-b9df-430581b69005)



# 💬 To Reviewers
### 👉 검색 플로우 수정(ebfe5c8d6f227f8905f351c10950669395adb9f3)
> 기존에는 영어 대소문자에 따라 검색이 불가능했었는데, 로직을 수정했습니다! 우선 플로우는 아래와 같습니다.

- 영어 대소문자 구분없이 검색 가능하도록
   - ex) "Naver", "NAVER"

- 띄어쓰기 구분
  - 검색어가 영어로만 이루어질 경우, 띄어쓰기 지켜야함 ex) Naver != na ver
  - 한글을 포함한 경우 띄어쓰기 무시 ex) "딜라이트 지원"과 "딜라이트지원" 모두 가능

<br/>

1. 영어 대소문자 구분없이 검색 가능하도록 -> LOWER() 사용
- 해당 함수는 오직 영문자에 대해서만 유효하게 동작하며, 대소문자 구분이 없는 한글 또는 특수기호 등은 해당 메서드를 적용해도 변화가 없다고 하네요!
https://github.com/teamterning/Terning-Server/blob/b7f20cd352d636932367eb5a830e960b523dc7ef/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java#L66

<br/>

2. 검색어가 순수 영문명인지, 아닌지(한글, 숫자포함) 판단 -> 정규 표현식 사용
https://github.com/teamterning/Terning-Server/blob/b7f20cd352d636932367eb5a830e960b523dc7ef/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java#L85-L88

<br/>

3. 위의 2번에 따라 검색 조건 달라집니다.
- 한글이나 숫자가 포함되어있으면 REPLACE() 사용하여 띄어쓰기에 관계없이 공고가 검색되게 하였습니다.
https://github.com/teamterning/Terning-Server/blob/b7f20cd352d636932367eb5a830e960b523dc7ef/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java#L90-L97

# 🔗 Reference
[참고한 블로그](https://velog.io/@carrotbat410/SQL-Querydsl-%EB%8C%80%EC%86%8C%EB%AC%B8%EC%9E%90-%EA%B5%AC%EB%B6%84-%EC%97%86%EC%9D%B4-%EA%B3%B5%EB%B0%B1-%EC%A0%9C%EA%B1%B0%ED%95%98%EC%97%AC-%EA%B2%80%EC%83%89%ED%95%98%EA%B8%B0-with.-RiotAPI-%EC%86%8C%ED%99%98%EC%82%AC%EB%AA%85-%EC%A1%B0%EA%B1%B4)