### PR TITLE
[♻️refactor] DateUtil에서 디데이를 계산할 때, 전체 일자를 고려해 날짜가 계산되도록 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/util/DateUtil.java
+++ b/src/main/java/org/terning/terningserver/util/DateUtil.java
@@ -1,8 +1,10 @@
 package org.terning.terningserver.util;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 public class DateUtil {
 
@@ -15,7 +17,7 @@ public class DateUtil {
         } else if (deadline.isBefore(currentDate)) {
             return "지원마감";
         } else {
-            long daysUntilDeadline = currentDate.until(deadline).getDays();
+            long daysUntilDeadline = ChronoUnit.DAYS.between(currentDate, deadline);
             return "D-" + daysUntilDeadline;
         }
     }


### PR DESCRIPTION
# 📄 Work Description
- [♻️refactor] DateUtil에서 디데이를 계산할 때, 전체 일자를 고려해 날짜가 계산되도록 수정했습니다.
- 오늘 날짜가 10월 27일 일 때, 10월 31일 공고는 D-4로 정상적으로 뜬다. 하지만 12월 31일 공고 또한 'D-4'로 동일하게 표기가 되는 현상을 발견했습니다.
- 디데이 계산 로직에 전체적인 deadline이 아닌 날짜만 반영되어 계산되어 생기는 오류로, `ChronoUnit.DAYS` 를 사용하여 deadline과 오늘 날짜 사이의 정확한 일 수를 계산하도록 `DateUtil.java` 로직을 수정했습니다.


# ⚙️ ISSUE
- closed #166 


# 📷 Screenshot
 -  오늘 날짜 10/27 <> 마감 날짜 12/31 (D-4가 아닌 D-65로 출력)
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/bea3bc73-d90a-457e-a0a8-9756e14de1e6">

