### PR TITLE
[♻️ refactor] N+1 문제 해결 및 HomeServiceImpl 성능 개선

### DIFF
--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -1,5 +1,6 @@
 package org.terning.terningserver.repository.internship_announcement;
 
+import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.terning.terningserver.domain.InternshipAnnouncement;
@@ -14,6 +15,5 @@ public interface InternshipRepositoryCustom {
 
     Page<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 
-    List<InternshipAnnouncement> findFilteredInternships(User user, String sortBy, int startYear, int startMonth);
-
+    List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, int startYear, int startMonth);
 }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.terning.terningserver.repository.internship_announcement;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -110,9 +111,10 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
 
 
     @Override
-    public List<InternshipAnnouncement> findFilteredInternships(User user, String sortBy, int startYear, int startMonth){
+    public List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, int startYear, int startMonth){
         return jpaQueryFactory
-                .selectFrom(internshipAnnouncement)
+                .select(internshipAnnouncement, scrap.id, scrap.color) // tuple -> Scrap 정보 한번에 불러오기
+                .from(internshipAnnouncement)
                 .leftJoin(internshipAnnouncement.scraps, scrap).on(scrap.user.eq(user))
                 .where(
                         getGraduatingFilter(user),

--- a/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
@@ -1,16 +1,20 @@
 package org.terning.terningserver.service;
 
+import static org.terning.terningserver.domain.QInternshipAnnouncement.internshipAnnouncement;
+import static org.terning.terningserver.domain.QScrap.scrap;
+
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.domain.User;
+import org.terning.terningserver.domain.enums.Color;
 import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 import org.terning.terningserver.dto.user.response.HomeResponseDto;
 import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.exception.enums.ErrorMessage;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
-import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
 
 import java.util.List;
@@ -22,7 +26,6 @@ public class HomeServiceImpl implements HomeService{
 
     private final InternshipRepository internshipRepository;
     private final UserRepository userRepository;
-    private final ScrapRepository scrapRepository;
 
     @Override
     public HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy, int startYear, int startMonth){
@@ -30,18 +33,29 @@ public class HomeServiceImpl implements HomeService{
                 () -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION)
         );
 
-        // 필터링 상태가 없을 경우 NULL 리턴
+        // 유저의 필터 정보가 없는 경우
         if(user.getFilter() == null){
             return HomeAnnouncementsResponseDto.of(0,List.of());
         }
 
-        List<InternshipAnnouncement> announcements = internshipRepository.findFilteredInternships(user, sortBy, startYear, startMonth);
+        List<Tuple> announcements = internshipRepository.findFilteredInternshipsWithScrapInfo(user, sortBy, startYear, startMonth);
+
+        // 해당하는 공고가 없는 경우
+        if(announcements.isEmpty()){
+            return HomeAnnouncementsResponseDto.of(0, List.of());
+        }
 
         List<HomeResponseDto> responseDtos = announcements.stream()
-                .map(announcement -> {
-                    boolean isScrapped = scrapRepository.existsByInternshipAnnouncementIdAndUserId(announcement.getId(), userId);
-                    String color = scrapRepository.findColorByInternshipAnnouncementIdAndUserId(announcement.getId(), userId);
-                    return HomeResponseDto.of(announcement, isScrapped, color);
+                .map(tuple -> {
+                    InternshipAnnouncement announcement = tuple.get(internshipAnnouncement);
+                    Long scrapId = tuple.get(scrap.id);
+                    Color color = tuple.get(scrap.color);
+                    boolean isScrapped = (scrapId != null); // 스크랩 여부
+
+                    // scrap 하지 않은 경우 color는 지정되지 않아야 한다.
+                    String colorValue = (isScrapped && color != null) ? color.getColorValue() : null;
+
+                    return HomeResponseDto.of(announcement, isScrapped, colorValue);
                 })
                 .toList();
 

--- a/src/test/java/org/terning/terningserver/test_plan.jmt
+++ b/src/test/java/org/terning/terningserver/test_plan.jmt
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="[홈 - 딱 맞는 대학생 인턴 공고] 공고 조회 (변경 전)" enabled="true">
+        <intProp name="ThreadGroup.num_threads">100</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <intProp name="LoopController.loops">-1</intProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/v1/home">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/v1/home?sortBy=deadlineSoon&amp;startYear=2024&amp;startMonth=12</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOjExLCJpYXQiOjE3MzM1NTc2NjYsImV4cCI6MTczNjE0ODY2Nn0.oDuEjKBf1YVaGo5u_fxVfznB7OEfeTg877ZbPBt4iyYDL5GJD7-CHAgqVIYa7I6w&apos;</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree (초기 테스트 용)">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="GraphVisualizer" testclass="ResultCollector" testname="결과 그래프">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="[홈 - 딱 맞는 대학생 인턴 공고] 공고 조회 (변경 후)">
+        <intProp name="ThreadGroup.num_threads">100</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <intProp name="LoopController.loops">-1</intProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/v1/home">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/v1/home?sortBy=deadlineSoon&amp;startYear=2024&amp;startMonth=12</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOjExLCJpYXQiOjE3MzM1NTc2NjYsImV4cCI6MTczNjE0ODY2Nn0.oDuEjKBf1YVaGo5u_fxVfznB7OEfeTg877ZbPBt4iyYDL5GJD7-CHAgqVIYa7I6w&apos;</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree (초기 테스트 용)">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="GraphVisualizer" testclass="ResultCollector" testname="결과 그래프">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
# 📄 Work Description
### ✨ Problem
- 현재 코드는 scrapRepository를 각 InternshipAnnouncement마다 호출함으로써 데이터베이스 접근이 비효율적으로 이루어지고 있어 해당 부분을 리펙토링하였습니다. (N+1 문제 발생)

### 🔧  Code Refactoring
- `QueryDSL Tuple`을 활용해 [**홈 - 나에게 딱 맞는 공고 API**]의 `공고 조회` 로직 성능을 크게 개선했습니다.
  - `Scrap` 정보를 한 번에 조회 하도록 변경했습니다.
  - `Enum` 타입으로 호출하여 컴파일 시 타입체크가 가능하도록 하였고, `Color` Enum의 내부 메서드를 통해 색상값을 불러오도록 수정했습니다.
  - 불필요한 메서드를 제거하고, `isScrapped` 로직을 좀 더 단순하게 수정했습니다.
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/3f28e14e-f439-42b7-a097-002c58c7454d">


## 🧪 Performance Test & 📄 Report
- 변경 전/후의 query 로직에 대한 비교를 위해 `JMeter` 도구를 활용해 성능 테스트를 진행했습니다.
- 대표적인 도구인 `k6`, `nGrinder`, `JMeter` 중 HTML 형식의 보고서가 잘 정리되어 있고, 레퍼런스의 규모와 사용성 측면에서 상당히 이점이 존재하는 JMeter를 사용하여 성능 테스트를 진행했습니다.

### Test Scenario
- Number Of Threads (users) : `100` -> `100`명의 사용자가 동시에 요청을 보냄
- Ramp-up period (seconds) : `1` -> 부하테스트를 진행할 것이기 때문에 쓰레드 수들을 나눠서 테스트 하지 않음
- Loop Count : Infinite (단, request가 총 `50000`회 응답할때까지 반복)

### Setting
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/9978a240-02e2-440f-ae5f-30b8c1922eeb">

- Protocol[http] -> http
- Server Name or IP -> `localhost` 혹은 `배포된 IP` 입력 (본인은 로컬에서 테스트했기 때문에 `localhost`로 설정함)
- Port Number(포트 번호) : `8080` (본인은 로컬에서 테스트했기 때문에 `8080`으로 설정함)
- HTTP Request -> `CREATE`/`GET`/`PUT`/`PATCH`/`DELETE` 등 선택
- Path ->  `/api/v1/home?sortBy=deadlineSoon&startYear=2024&startMonth=12`  ([**홈 - 나에게 딱 맞는 공고 API**]를 기준으로 설정함)
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/c284e462-8c19-4d2e-8698-4b3a5cec0af8">

- HTTP Header의 `Name` 에는 `Authorization`, `Value` 에는 `Bearer 토큰` 입력

### **Result (개선 전)**
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/39a87052-e801-42f6-9dc3-9aa29e649841">

- number of Samples(샘플 수) : `50831`
- Average(평균 응답 속도) : `75ms`
- Error %(오류율) : `0.20%`
- Throughput(처리량) : `1292.8/sec`
- Reseived KB/sec(클라이언트(JMeter)가 서버로부터 초당 수신하는 데이터의 양) : `6814.23KB/sec`
- Sent KB/sec(클라이언트(JMeter)가 서버로 초당 전송하는 데이터의 양) : `461.17KB/sec`

### **Result (개선 후)**
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/f490e729-ea7b-4a96-befd-6b96337975b0">

- number of Samples(샘플 수) : `50600`
- Average(평균 응답 속도) : `29ms`
- Error %(오류율) : `0.20%` (동일)
- Throughput(처리량) : `3272.5/sec`
- Reseived KB/sec(클라이언트(JMeter)가 서버로부터 초당 수신하는 데이터의 양) : `17249.02KB/sec`
- Sent KB/sec(클라이언트(JMeter)가 서버로 초당 전송하는 데이터의 양) : `1167.37KB/sec`

## 최종 Result
### Average(평균 응답 속도)
이전: `75ms`
개선: `29ms`
개선율 = ((75ms - 29ms) / 75ms) * 100 ≈ `61.3%` 단축
→ 평균 응답 시간이 약 `61.3%` 개선(낮을수록 좋으므로 단축률로 표시)

### Error %(오류율) :

이전: `0.20%`
개선: `0.20%`
개선율 = ((0.20% - 0.20%) / 0.20%) * 100 = `0`%
→ 오류율 변화 없음

### Throughput(처리량) :

이전: `1292.8/sec`
개선: `3272.5/sec`
개선율 = ((3272.5 - 1292.8) / 1292.8) * 100 ≈ `153%` 증가
→ 처리량 약 `153%` 향상 (약 `2.5`배)

### Received KB/sec:

이전: `6814.23KB/sec`
개선: `17249.02KB/sec`
개선율 = ((17249.02 - 6814.23) / 6814.23) * 100 ≈ `153%` 증가
→ 수신 데이터량 약 `153%` 증가 (약 `2.5`배)

### Sent KB/sec:

이전: `461.17KB/sec`
개선: `1167.37KB/sec`
개선율 = ((1167.37 - 461.17) / 461.17) * 100 ≈ `153%` 증가
→ 전송 데이터량 약 `153%` 증가


# ⚙️ ISSUE
- closed #177 


# 🔗 Reference
- [Apache JMeter를 이용한 부하 테스트 및 리포트 생성(1)](https://creampuffy.tistory.com/209)
- [Apache JMeter를 이용한 부하 테스트 및 리포트 생성(2)](https://m.blog.naver.com/wisestone2007/222160380337)
