### PR TITLE
[♻️ refactor/#179] 나에게 딱 맞는 대학생 인턴 공고 API Query Parameter 재조정

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -26,11 +26,9 @@ public class HomeController implements HomeSwagger {
     @GetMapping("/home")
     public ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             @AuthenticationPrincipal Long userId,
-            @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy,
-            @RequestParam("startYear") int startYear,
-            @RequestParam("startMonth") int startMonth
+            @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy
     ){
-        HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy, startYear, startMonth);
+        HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy);
 
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
     }

--- a/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
@@ -15,9 +15,7 @@ public interface HomeSwagger {
     @Operation(summary = "홈화면 > 나에게 딱맞는 인턴 공고 조회", description = "특정 사용자에 필터링 조건에 맞는 인턴 공고 정보를 조회하는 API")
     ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             Long userId,
-            String sortBy,
-            int startYear,
-            int startMonth
+            String sortBy
     );
 
     @Operation(summary = "홈화면 > 곧 마감인 스크랩 공고 조회", description = "곧 마감인 스크랩 공고를 조회하는 API")

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -15,6 +15,6 @@ public interface InternshipRepositoryCustom {
 
     Page<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 
-    List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, int startYear, int startMonth);
+    List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy);
 
 }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -109,7 +109,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     }
 
     @Override
-    public List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, int startYear, int startMonth){
+    public List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy){
         return jpaQueryFactory
                 .select(internshipAnnouncement, scrap.id, scrap.color) // tuple -> Scrap 정보 한번에 불러오기
                 .from(internshipAnnouncement)
@@ -117,7 +117,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .where(
                         getGraduatingFilter(user),
                         getWorkingPeriodFilter(user),
-                        getStartDateFilter(startYear, startMonth)
+                        getStartDateFilter(user)
                 )
                 .orderBy(
                         sortAnnouncementsByDeadline().asc(),
@@ -143,7 +143,9 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
         }
     }
 
-    private BooleanExpression getStartDateFilter(int startYear, int startMonth){
+    private BooleanExpression getStartDateFilter(User user){
+        int startYear = user.getFilter().getStartYear();
+        int startMonth = user.getFilter().getStartMonth();
         return internshipAnnouncement.startYear.eq(startYear)
                 .and(internshipAnnouncement.startMonth.eq(startMonth));
     }

--- a/src/main/java/org/terning/terningserver/service/HomeService.java
+++ b/src/main/java/org/terning/terningserver/service/HomeService.java
@@ -4,5 +4,5 @@ import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 
 public interface HomeService {
 
-    HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy, int startYear, int startMonth);
+    HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy);
 }

--- a/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/HomeServiceImpl.java
@@ -28,7 +28,7 @@ public class HomeServiceImpl implements HomeService{
     private final UserRepository userRepository;
 
     @Override
-    public HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy, int startYear, int startMonth){
+    public HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy){
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new CustomException(ErrorMessage.NOT_FOUND_USER_EXCEPTION)
         );
@@ -38,7 +38,7 @@ public class HomeServiceImpl implements HomeService{
             return HomeAnnouncementsResponseDto.of(0,List.of());
         }
 
-        List<Tuple> announcements = internshipRepository.findFilteredInternshipsWithScrapInfo(user, sortBy, startYear, startMonth);
+        List<Tuple> announcements = internshipRepository.findFilteredInternshipsWithScrapInfo(user, sortBy);
 
         // 해당하는 공고가 없는 경우
         if(announcements.isEmpty()){

--- a/src/test/java/org/terning/terningserver/service/legacy/HomeServicePerformanceTest.java
+++ b/src/test/java/org/terning/terningserver/service/legacy/HomeServicePerformanceTest.java
@@ -1,190 +1,190 @@
-package org.terning.terningserver.service.legacy;
-
-import com.querydsl.core.Tuple;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-import org.terning.terningserver.domain.Company;
-import org.terning.terningserver.domain.Filter;
-import org.terning.terningserver.domain.InternshipAnnouncement;
-import org.terning.terningserver.domain.User;
-import org.terning.terningserver.domain.enums.Grade;
-import org.terning.terningserver.domain.enums.WorkingPeriod;
-import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
-import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
-import org.terning.terningserver.repository.user.UserRepository;
-import org.terning.terningserver.service.HomeServiceImpl;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.terning.terningserver.domain.QInternshipAnnouncement.internshipAnnouncement;
-import static org.terning.terningserver.domain.QScrap.scrap;
-
-@SpringBootTest
-@Transactional
-class HomeServicePerformanceTest {
-
-    private static final Logger logger = LoggerFactory.getLogger(HomeServicePerformanceTest.class);
-
-    @Autowired
-    private HomeServiceImpl homeService;
-
-    private UserRepository userRepository;
-    private InternshipRepository internshipRepository;
-
-    @BeforeEach
-    void setUp() {
-        userRepository = Mockito.mock(UserRepository.class);
-        internshipRepository = Mockito.mock(InternshipRepository.class);
-        homeService = new HomeServiceImpl(internshipRepository, userRepository);
-
-        setUpMockData();
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideTestParameters")
-    @DisplayName("성능 테스트: 다양한 조건에서 공고 데이터 조회")
-    void testGetAnnouncementsPerformance(TestParameters params) {
-        logTestConditions(params);
-
-        long startTime = System.currentTimeMillis();
-        HomeAnnouncementsResponseDto response = homeService.getAnnouncements(
-                params.userId, params.sortBy, params.startYear, params.startMonth);
-        long endTime = System.currentTimeMillis();
-
-        validateResponse(response);
-        logTestResults(response, endTime - startTime);
-    }
-
-    private void setUpMockData() {
-        User mockUser1 = createMockUser(1L, Grade.SENIOR, WorkingPeriod.OPTION2, 2024, 1);
-        User mockUser2 = createMockUser(2L, Grade.JUNIOR, WorkingPeriod.OPTION1, 2023, 12);
-
-        Mockito.when(userRepository.findById(1L)).thenReturn(java.util.Optional.of(mockUser1));
-        Mockito.when(userRepository.findById(2L)).thenReturn(java.util.Optional.of(mockUser2));
-
-        List<Tuple> singleAnnouncement = createMockAnnouncementTuples(1);
-        List<Tuple> hundredAnnouncements = createMockAnnouncementTuples(100);
-        List<Tuple> thousandAnnouncements = createMockAnnouncementTuples(1000);
-
-        Mockito.when(internshipRepository.findFilteredInternshipsWithScrapInfo(Mockito.eq(mockUser1), Mockito.any(), Mockito.eq(2024), Mockito.eq(1)))
-                .thenReturn(singleAnnouncement);
-        Mockito.when(internshipRepository.findFilteredInternshipsWithScrapInfo(Mockito.eq(mockUser1), Mockito.any(), Mockito.eq(2023), Mockito.eq(12)))
-                .thenReturn(hundredAnnouncements);
-        Mockito.when(internshipRepository.findFilteredInternshipsWithScrapInfo(Mockito.eq(mockUser2), Mockito.any(), Mockito.eq(2024), Mockito.eq(2)))
-                .thenReturn(thousandAnnouncements);
-    }
-
-    private List<Tuple> createMockAnnouncementTuples(int count) {
-        List<Tuple> tuples = new ArrayList<>();
-        for (int i = 1; i <= count; i++) {
-            InternshipAnnouncement announcement = createMockAnnouncement(
-                    (long) i,
-                    "터닝 인턴쉽 " + i,
-                    LocalDate.of(2024, 12, 31),
-                    "6 months",
-                    2024,
-                    1
-            );
-            Tuple tuple = Mockito.mock(Tuple.class);
-            Mockito.when(tuple.get(internshipAnnouncement)).thenReturn(announcement);
-            Mockito.when(tuple.get(scrap.id)).thenReturn(null);
-            Mockito.when(tuple.get(scrap.color)).thenReturn(null);
-            tuples.add(tuple);
-        }
-        return tuples;
-    }
-
-    private User createMockUser(Long id, Grade grade, WorkingPeriod period, int startYear, int startMonth) {
-        Filter filter = Filter.builder()
-                .grade(grade)
-                .workingPeriod(period)
-                .startYear(startYear)
-                .startMonth(startMonth)
-                .build();
-        return User.builder()
-                .id(id)
-                .filter(filter)
-                .build();
-    }
-
-    private InternshipAnnouncement createMockAnnouncement(Long id, String title, LocalDate deadline, String period, int startYear, int startMonth) {
-        Company mockCompany = Mockito.mock(Company.class);
-        Mockito.when(mockCompany.getCompanyImage()).thenReturn("https://example.com/company/image.png");
-
-        InternshipAnnouncement announcement = Mockito.mock(InternshipAnnouncement.class);
-        Mockito.when(announcement.getId()).thenReturn(id);
-        Mockito.when(announcement.getTitle()).thenReturn(title);
-        Mockito.when(announcement.getDeadline()).thenReturn(deadline);
-        Mockito.when(announcement.getWorkingPeriod()).thenReturn(period);
-        Mockito.when(announcement.getStartYear()).thenReturn(startYear);
-        Mockito.when(announcement.getStartMonth()).thenReturn(startMonth);
-        Mockito.when(announcement.getCompany()).thenReturn(mockCompany);
-        return announcement;
-    }
-
-    private void logTestConditions(TestParameters params) {
-        logger.info("=======================================");
-        logger.info("🟢 [성능 테스트 시작]");
-        logger.info("---------------------------------------");
-        logger.info("▶ 테스트 조건:");
-        logger.info("   - User ID       : {}", params.userId);
-        logger.info("   - Sort By       : {}", params.sortBy);
-        logger.info("   - Start Year    : {}", params.startYear);
-        logger.info("   - Start Month   : {}", params.startMonth);
-        logger.info("---------------------------------------");
-    }
-
-    private void validateResponse(HomeAnnouncementsResponseDto response) {
-        logger.info("🟡 [응답 데이터 검증]");
-        logger.info("   - 응답 총 공고 수 : {}", response.totalCount());
-        if (response.totalCount() <= 0) {
-            logger.error("❌ 예상된 데이터가 없습니다. totalCount = 0");
-        }
-        assertThat(response).isNotNull();
-        assertThat(response.totalCount()).isGreaterThan(0);
-        assertThat(response.result()).isNotEmpty();
-    }
-
-    private void logTestResults(HomeAnnouncementsResponseDto response, long elapsedTime) {
-        logger.info("🟡 [테스트 결과]");
-        logger.info("   - 총 공고 수        : {}", response.totalCount());
-        logger.info("   - 결과 목록 크기    : {}", response.result().size());
-        logger.info("   - 실행 시간         : {}ms", elapsedTime);
-        logger.info("---------------------------------------");
-    }
-
-    static Stream<TestParameters> provideTestParameters() {
-        return Stream.of(
-                new TestParameters(1L, "date", 2024, 1),
-                new TestParameters(1L, "popularity", 2023, 12),
-                new TestParameters(2L, "date", 2024, 2)
-        );
-    }
-
-    static class TestParameters {
-        Long userId;
-        String sortBy;
-        int startYear;
-        int startMonth;
-
-        public TestParameters(Long userId, String sortBy, int startYear, int startMonth) {
-            this.userId = userId;
-            this.sortBy = sortBy;
-            this.startYear = startYear;
-            this.startMonth = startMonth;
-        }
-    }
-}
-
+//package org.terning.terningserver.service.legacy;
+//
+//import com.querydsl.core.Tuple;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.params.ParameterizedTest;
+//import org.junit.jupiter.params.provider.MethodSource;
+//import org.mockito.Mockito;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.transaction.annotation.Transactional;
+//import org.terning.terningserver.domain.Company;
+//import org.terning.terningserver.domain.Filter;
+//import org.terning.terningserver.domain.InternshipAnnouncement;
+//import org.terning.terningserver.domain.User;
+//import org.terning.terningserver.domain.enums.Grade;
+//import org.terning.terningserver.domain.enums.WorkingPeriod;
+//import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
+//import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
+//import org.terning.terningserver.repository.user.UserRepository;
+//import org.terning.terningserver.service.HomeServiceImpl;
+//
+//import java.time.LocalDate;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.stream.Stream;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.terning.terningserver.domain.QInternshipAnnouncement.internshipAnnouncement;
+//import static org.terning.terningserver.domain.QScrap.scrap;
+//
+//@SpringBootTest
+//@Transactional
+//class HomeServicePerformanceTest {
+//
+//    private static final Logger logger = LoggerFactory.getLogger(HomeServicePerformanceTest.class);
+//
+//    @Autowired
+//    private HomeServiceImpl homeService;
+//
+//    private UserRepository userRepository;
+//    private InternshipRepository internshipRepository;
+//
+//    @BeforeEach
+//    void setUp() {
+//        userRepository = Mockito.mock(UserRepository.class);
+//        internshipRepository = Mockito.mock(InternshipRepository.class);
+//        homeService = new HomeServiceImpl(internshipRepository, userRepository);
+//
+//        setUpMockData();
+//    }
+//
+//    @ParameterizedTest
+//    @MethodSource("provideTestParameters")
+//    @DisplayName("성능 테스트: 다양한 조건에서 공고 데이터 조회")
+//    void testGetAnnouncementsPerformance(TestParameters params) {
+//        logTestConditions(params);
+//
+//        long startTime = System.currentTimeMillis();
+//        HomeAnnouncementsResponseDto response = homeService.getAnnouncements(
+//                params.userId, params.sortBy);
+//        long endTime = System.currentTimeMillis();
+//
+//        validateResponse(response);
+//        logTestResults(response, endTime - startTime);
+//    }
+//
+//    private void setUpMockData() {
+//        User mockUser1 = createMockUser(1L, Grade.SENIOR, WorkingPeriod.OPTION2, 2024, 1);
+//        User mockUser2 = createMockUser(2L, Grade.JUNIOR, WorkingPeriod.OPTION1, 2023, 12);
+//
+//        Mockito.when(userRepository.findById(1L)).thenReturn(java.util.Optional.of(mockUser1));
+//        Mockito.when(userRepository.findById(2L)).thenReturn(java.util.Optional.of(mockUser2));
+//
+//        List<Tuple> singleAnnouncement = createMockAnnouncementTuples(1);
+//        List<Tuple> hundredAnnouncements = createMockAnnouncementTuples(100);
+//        List<Tuple> thousandAnnouncements = createMockAnnouncementTuples(1000);
+//
+//        Mockito.when(internshipRepository.findFilteredInternshipsWithScrapInfo(Mockito.eq(mockUser1), Mockito.any()))
+//                .thenReturn(singleAnnouncement);
+//        Mockito.when(internshipRepository.findFilteredInternshipsWithScrapInfo(Mockito.eq(mockUser1), Mockito.any()))
+//                .thenReturn(hundredAnnouncements);
+//        Mockito.when(internshipRepository.findFilteredInternshipsWithScrapInfo(Mockito.eq(mockUser2), Mockito.any()))
+//                .thenReturn(thousandAnnouncements);
+//    }
+//
+//    private List<Tuple> createMockAnnouncementTuples(int count) {
+//        List<Tuple> tuples = new ArrayList<>();
+//        for (int i = 1; i <= count; i++) {
+//            InternshipAnnouncement announcement = createMockAnnouncement(
+//                    (long) i,
+//                    "터닝 인턴쉽 " + i,
+//                    LocalDate.of(2024, 12, 31),
+//                    "6 months",
+//                    2024,
+//                    1
+//            );
+//            Tuple tuple = Mockito.mock(Tuple.class);
+//            Mockito.when(tuple.get(internshipAnnouncement)).thenReturn(announcement);
+//            Mockito.when(tuple.get(scrap.id)).thenReturn(null);
+//            Mockito.when(tuple.get(scrap.color)).thenReturn(null);
+//            tuples.add(tuple);
+//        }
+//        return tuples;
+//    }
+//
+//    private User createMockUser(Long id, Grade grade, WorkingPeriod period, int startYear, int startMonth) {
+//        Filter filter = Filter.builder()
+//                .grade(grade)
+//                .workingPeriod(period)
+//                .startYear(startYear)
+//                .startMonth(startMonth)
+//                .build();
+//        return User.builder()
+//                .id(id)
+//                .filter(filter)
+//                .build();
+//    }
+//
+//    private InternshipAnnouncement createMockAnnouncement(Long id, String title, LocalDate deadline, String period, int startYear, int startMonth) {
+//        Company mockCompany = Mockito.mock(Company.class);
+//        Mockito.when(mockCompany.getCompanyImage()).thenReturn("https://example.com/company/image.png");
+//
+//        InternshipAnnouncement announcement = Mockito.mock(InternshipAnnouncement.class);
+//        Mockito.when(announcement.getId()).thenReturn(id);
+//        Mockito.when(announcement.getTitle()).thenReturn(title);
+//        Mockito.when(announcement.getDeadline()).thenReturn(deadline);
+//        Mockito.when(announcement.getWorkingPeriod()).thenReturn(period);
+//        Mockito.when(announcement.getStartYear()).thenReturn(startYear);
+//        Mockito.when(announcement.getStartMonth()).thenReturn(startMonth);
+//        Mockito.when(announcement.getCompany()).thenReturn(mockCompany);
+//        return announcement;
+//    }
+//
+//    private void logTestConditions(TestParameters params) {
+//        logger.info("=======================================");
+//        logger.info("🟢 [성능 테스트 시작]");
+//        logger.info("---------------------------------------");
+//        logger.info("▶ 테스트 조건:");
+//        logger.info("   - User ID       : {}", params.userId);
+//        logger.info("   - Sort By       : {}", params.sortBy);
+//        logger.info("   - Start Year    : {}", params.startYear);
+//        logger.info("   - Start Month   : {}", params.startMonth);
+//        logger.info("---------------------------------------");
+//    }
+//
+//    private void validateResponse(HomeAnnouncementsResponseDto response) {
+//        logger.info("🟡 [응답 데이터 검증]");
+//        logger.info("   - 응답 총 공고 수 : {}", response.totalCount());
+//        if (response.totalCount() <= 0) {
+//            logger.error("❌ 예상된 데이터가 없습니다. totalCount = 0");
+//        }
+//        assertThat(response).isNotNull();
+//        assertThat(response.totalCount()).isGreaterThan(0);
+//        assertThat(response.result()).isNotEmpty();
+//    }
+//
+//    private void logTestResults(HomeAnnouncementsResponseDto response, long elapsedTime) {
+//        logger.info("🟡 [테스트 결과]");
+//        logger.info("   - 총 공고 수        : {}", response.totalCount());
+//        logger.info("   - 결과 목록 크기    : {}", response.result().size());
+//        logger.info("   - 실행 시간         : {}ms", elapsedTime);
+//        logger.info("---------------------------------------");
+//    }
+//
+//    static Stream<TestParameters> provideTestParameters() {
+//        return Stream.of(
+//                new TestParameters(1L, "date", 2024, 1),
+//                new TestParameters(1L, "popularity", 2023, 12),
+//                new TestParameters(2L, "date", 2024, 2)
+//        );
+//    }
+//
+//    static class TestParameters {
+//        Long userId;
+//        String sortBy;
+//        int startYear;
+//        int startMonth;
+//
+//        public TestParameters(Long userId, String sortBy, int startYear, int startMonth) {
+//            this.userId = userId;
+//            this.sortBy = sortBy;
+//            this.startYear = startYear;
+//            this.startMonth = startMonth;
+//        }
+//    }
+//}
+//

--- a/test_plan.jmt
+++ b/test_plan.jmt
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="[홈 - 딱 맞는 대학생 인턴 공고] 공고 조회 (변경 전)">
+        <intProp name="ThreadGroup.num_threads">100</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <intProp name="LoopController.loops">-1</intProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/v1/home">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/v1/home?sortBy=deadlineSoon&amp;startYear=2024&amp;startMonth=12 </stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOjExLCJpYXQiOjE3MzM1NTc2NjYsImV4cCI6MTczNjE0ODY2Nn0.oDuEjKBf1YVaGo5u_fxVfznB7OEfeTg877ZbPBt4iyYDL5GJD7-CHAgqVIYa7I6w&apos;</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree (초기 테스트 용)">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="GraphVisualizer" testclass="ResultCollector" testname="결과 그래프">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="[홈 - 딱 맞는 대학생 인턴 공고] 공고 조회 (변경 후)">
+        <intProp name="ThreadGroup.num_threads">100</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <intProp name="LoopController.loops">-1</intProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/v1/home">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/api/v1/home?sortBy=deadlineSoon&amp;startYear=2024&amp;startMonth=12</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOjExLCJpYXQiOjE3MzM1NTc2NjYsImV4cCI6MTczNjE0ODY2Nn0.oDuEjKBf1YVaGo5u_fxVfznB7OEfeTg877ZbPBt4iyYDL5GJD7-CHAgqVIYa7I6w&apos;</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree (초기 테스트 용)">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="GraphVisualizer" testclass="ResultCollector" testname="결과 그래프">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
# 📄 Work Description
- [♻️ refactor] 나에게 딱 맞는 대학생 인턴 공고 API Query Parameter 재조정
- 기존의 Query Parameter로 받아왔던 year과 month를 모두 삭제하고, 사용자의 필터링 정보 기반으로 공고를 필터링하도록 로직을 전면 수정했습니다.

# ⚙️ ISSUE
- closed #179 


# 📷 Screenshot
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/1e55cb1f-b9ac-4b7e-8a0f-1e1c9e35d2fa">
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/d4caba96-440b-4c21-a593-da60c54e4a5d">

