### PR TITLE
[✨ feat] 직무필터링, 사용자 필터링 정보, 필터링 재설정(직무, 계획) API 구현

### DIFF
--- a/src/main/java/org/terning/terningserver/domain/Filter.java
+++ b/src/main/java/org/terning/terningserver/domain/Filter.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.terning.terningserver.domain.enums.Grade;
+import org.terning.terningserver.domain.enums.JobType;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
-import org.terning.terningserver.dto.auth.request.SignUpFilterRequestDto;
 
 import static lombok.AccessLevel.PROTECTED;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -24,6 +24,9 @@ public class Filter {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    private JobType jobType;
+
+    @Enumerated(EnumType.STRING)
     private Grade grade;
 
     @Enumerated(EnumType.STRING)
@@ -34,7 +37,8 @@ public class Filter {
     private int startMonth; // 근무 시작 월
 
 
-    public void updateFilter(Grade grade, WorkingPeriod workingPeriod, int startYear, int startMonth) {
+    public void updateFilter(JobType jobType, Grade grade, WorkingPeriod workingPeriod, int startYear, int startMonth) {
+        this.jobType = jobType;
         this.grade = grade;
         this.workingPeriod = workingPeriod;
         this.startYear = startYear;

--- a/src/main/java/org/terning/terningserver/domain/enums/JobType.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/JobType.java
@@ -1,0 +1,33 @@
+package org.terning.terningserver.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.terning.terningserver.exception.CustomException;
+import org.terning.terningserver.exception.enums.ErrorMessage;
+
+@Getter
+@RequiredArgsConstructor
+public enum JobType {
+    TOTAL("total", "전체"),
+    PLAN("plan", "기획/전략"),
+    MARKETING("marketing", "마케팅/홍보"),
+    ADMIN("admin", "사무/회계"),
+    SALES("sales", "인사/영업"),
+    DESIGN("design", "디자인/예술"),
+    IT("it", "개발/IT"),
+    RESEARCH("research", "연구/생산"),
+    ETC("etc", "기타");
+
+    private final String key;
+    private final String value;
+
+    public static JobType fromKey(String key) {
+        for (JobType jobType : JobType.values()) {
+            if (jobType.key.equalsIgnoreCase(key)) {
+                return jobType;
+            }
+        }
+        throw new CustomException(ErrorMessage.INVALID_JOB_TYPE);
+    }
+
+}

--- a/src/main/java/org/terning/terningserver/dto/filter/request/UpdateUserFilterRequestDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/request/UpdateUserFilterRequestDto.java
@@ -1,6 +1,7 @@
 package org.terning.terningserver.dto.filter.request;
 
 public record UpdateUserFilterRequestDto(
+        String jobType,
         String grade,
         String workingPeriod,
         int startYear,

--- a/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/filter/response/UserFilterDetailResponseDto.java
@@ -7,6 +7,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record UserFilterDetailResponseDto(
+        String jobType,
         String grade,
         String workingPeriod,
         Integer startYear,
@@ -14,8 +15,9 @@ public record UserFilterDetailResponseDto(
 ) {
     public static UserFilterDetailResponseDto of(final Filter userFilter) {
         return UserFilterDetailResponseDto.builder()
-                .grade(userFilter == null ? null : userFilter.getGrade().getKey())
-                .workingPeriod(userFilter == null ? null : userFilter.getWorkingPeriod().getKey())
+                .jobType(userFilter == null || userFilter.getJobType() == null ? "total" : userFilter.getJobType().getKey())
+                .grade(userFilter == null || userFilter.getGrade() == null ? null : userFilter.getGrade().getKey())
+                .workingPeriod(userFilter == null || userFilter.getWorkingPeriod() == null ? null : userFilter.getWorkingPeriod().getKey())
                 .startYear(userFilter == null ? null : userFilter.getStartYear())
                 .startMonth(userFilter == null ? null : userFilter.getStartMonth())
                 .build();

--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -15,9 +15,10 @@ public enum ErrorMessage {
     FAILED_TOKEN_REISSUE(404, "토큰 재발급에 실패하였습니다"),
     UNAUTHORIZED_JWT_EXCEPTION(401, "유효하지 않은 토큰입니다"),
 
-    // 사용자 필터링 정보 생성
+    // 필터링
     FAILED_SIGN_UP_USER_FILTER_CREATION(404, "사용자 필터 생성에 실패하였습니다"),
     FAILED_SIGN_UP_USER_FILTER_ASSIGNMENT(404, "사용자 필터 연결에 실패하였습니다"),
+    INVALID_JOB_TYPE(401, "유효하지 않은 직무 카테고리입니다."),
 
     // 스크랩
     EXISTS_SCRAP_ALREADY(400, "이미 스크랩했습니다."),

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.terning.terningserver.domain.InternshipAnnouncement;
 import org.terning.terningserver.domain.enums.Grade;
+import org.terning.terningserver.domain.enums.JobType;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
 
 
@@ -115,6 +116,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 .from(internshipAnnouncement)
                 .leftJoin(internshipAnnouncement.scraps, scrap).on(scrap.user.eq(user))
                 .where(
+                        getJobTypeFilter(user),
                         getGraduatingFilter(user),
                         getWorkingPeriodFilter(user),
                         getStartDateFilter(user)
@@ -198,5 +200,12 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                 "CASE WHEN {0} THEN 1 ELSE 2 END",
                 isNotExpired
         );
+    }
+
+    private BooleanExpression getJobTypeFilter(User user) {
+        if (user.getFilter().getJobType() == JobType.TOTAL) {
+            return null; // total일 경우 모든 직무 공고 허용
+        }
+        return internshipAnnouncement.jobType.eq(user.getFilter().getJobType().getValue());
     }
 }

--- a/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import org.terning.terningserver.domain.Filter;
 import org.terning.terningserver.domain.Token;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
+import org.terning.terningserver.domain.enums.JobType;
 import org.terning.terningserver.domain.enums.ProfileImage;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
 import org.terning.terningserver.dto.auth.request.SignInRequestDto;
@@ -208,12 +209,14 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private Filter buildFilterFromRequest(SignUpFilterRequestDto request) {
+        JobType jobType = JobType.TOTAL;
         Grade grade = Grade.fromKey(request.grade());
         WorkingPeriod workingPeriod = WorkingPeriod.fromKey(request.workingPeriod());
         int startYear = request.startYear();
         int startMonth = request.startMonth();
 
         return Filter.builder()
+                .jobType(jobType)
                 .grade(grade)
                 .workingPeriod(workingPeriod)
                 .startYear(startYear)

--- a/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/FilterServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.terning.terningserver.domain.Filter;
 import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.Grade;
+import org.terning.terningserver.domain.enums.JobType;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
 import org.terning.terningserver.dto.filter.request.UpdateUserFilterRequestDto;
 import org.terning.terningserver.dto.filter.response.UserFilterDetailResponseDto;
@@ -35,14 +36,16 @@ public class FilterServiceImpl implements FilterService {
         User user = findUser(userId);
         Filter filter = user.getFilter();
 
+        JobType jobType = (responseDto.jobType() == null || responseDto.jobType().isBlank())
+                ? JobType.TOTAL : JobType.fromKey(responseDto.jobType());
         Grade grade = Grade.fromKey(responseDto.grade());
         WorkingPeriod workingPeriod = WorkingPeriod.fromKey(responseDto.workingPeriod());
 
         if (filter != null) {
-            updateExistingFilter(filter, grade, workingPeriod, responseDto);
+            updateExistingFilter(filter, jobType, grade, workingPeriod, responseDto);
         }
 
-        createFilter(user, grade, workingPeriod, responseDto);
+        createFilter(user, jobType, grade, workingPeriod, responseDto);
     }
 
     private User findUser(Long userId) {
@@ -50,8 +53,9 @@ public class FilterServiceImpl implements FilterService {
                 .orElseThrow(() -> new CustomException(NOT_FOUND_USER_EXCEPTION));
     }
 
-    private void updateExistingFilter(Filter filter, Grade grade, WorkingPeriod workingPeriod, UpdateUserFilterRequestDto dto) {
+    private void updateExistingFilter(Filter filter, JobType jobType, Grade grade, WorkingPeriod workingPeriod, UpdateUserFilterRequestDto dto) {
         filter.updateFilter(
+                jobType,
                 grade,
                 workingPeriod,
                 dto.startYear(),
@@ -59,9 +63,10 @@ public class FilterServiceImpl implements FilterService {
         );
     }
 
-    private void createFilter(User user, Grade grade, WorkingPeriod workingPeriod, UpdateUserFilterRequestDto dto) {
+    private void createFilter(User user, JobType jobType, Grade grade, WorkingPeriod workingPeriod, UpdateUserFilterRequestDto dto) {
         Filter savedFilter = filterRepository.save(
                 Filter.builder()
+                        .jobType(jobType)
                         .grade(grade)
                         .workingPeriod(workingPeriod)
                         .startYear(dto.startYear())


### PR DESCRIPTION
# 📄 Work Description
- [✨ feat] 직무필터링, 사용자 필터링 정보, 필터링 재설정(직무, 계획) API 구현

- 사용자의 직무 필터링(jobType)과 계획 필터링 사항을 모두 한번에 수정하는 필터링 제설정 API와 필터링 정보를 불러오는 API를 구현합니다.

# ⚙️ ISSUE
- closed #181 


# 📷 Screenshot
 
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/57be2f7e-3f91-4ea0-9af2-a5990bddba0a" />
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/b9500d26-3128-4013-b98f-ba4f6b00a452" />


# 💬 To Reviewers
- 직무필터링이 추가되면서, 직무필터링을 한번도 설정하지 않았던 유저들은 total로 설정되도록 구현했습니다.
- 직무를 Enum으로 관리하고, 해당 필드를 사용해 기존의 응답에 추가로 직무정보를 응답하도록 구현했습니다.
