### PR TITLE
[✨feat/#185]: 공고 조회 페이지네이션 기능 도입 및 서비스 로직 개선

### DIFF
--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -31,7 +31,6 @@ public class HomeController implements HomeSwagger {
             @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy,
             @PageableDefault(size = 10) Pageable pageable) {
         HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy, pageable);
-
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
     }
 

--- a/src/main/java/org/terning/terningserver/controller/HomeController.java
+++ b/src/main/java/org/terning/terningserver/controller/HomeController.java
@@ -1,6 +1,8 @@
 package org.terning.terningserver.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,12 +28,13 @@ public class HomeController implements HomeSwagger {
     @GetMapping("/home")
     public ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             @AuthenticationPrincipal Long userId,
-            @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy
-    ){
-        HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy);
+            @RequestParam(value = "sortBy", required = false, defaultValue = "deadlineSoon") String sortBy,
+            @PageableDefault(size = 10) Pageable pageable) {
+        HomeAnnouncementsResponseDto announcements = homeService.getAnnouncements(userId, sortBy, pageable);
 
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_ANNOUNCEMENTS, announcements));
     }
+
 
     @GetMapping("/home/upcoming")
     public ResponseEntity<SuccessResponse<List<UpcomingScrapResponseDto>>> getUpcomingScraps(

--- a/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/HomeSwagger.java
@@ -2,6 +2,7 @@ package org.terning.terningserver.controller.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 import org.terning.terningserver.dto.user.response.UpcomingScrapResponseDto;
@@ -15,7 +16,8 @@ public interface HomeSwagger {
     @Operation(summary = "홈화면 > 나에게 딱맞는 인턴 공고 조회", description = "특정 사용자에 필터링 조건에 맞는 인턴 공고 정보를 조회하는 API")
     ResponseEntity<SuccessResponse<HomeAnnouncementsResponseDto>> getAnnouncements(
             Long userId,
-            String sortBy
+            String sortBy,
+            Pageable pageable
     );
 
     @Operation(summary = "홈화면 > 곧 마감인 스크랩 공고 조회", description = "곧 마감인 스크랩 공고를 조회하는 API")

--- a/src/main/java/org/terning/terningserver/dto/user/response/HomeAnnouncementsResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/HomeAnnouncementsResponseDto.java
@@ -6,12 +6,20 @@ import java.util.List;
 
 @Builder
 public record HomeAnnouncementsResponseDto(
-        int totalCount, // 필터링 된 공고 총 개수
+        int totalPages,
+        long totalCount,
+        boolean hasNext,
         List<HomeResponseDto> result
 ) {
-    public static HomeAnnouncementsResponseDto of(final int totalCount, final List<HomeResponseDto> announcements){
+    public static HomeAnnouncementsResponseDto of(
+            final int totalPages,
+            final long totalCount,
+            final boolean hasNext,
+            final List<HomeResponseDto> announcements) {
         return HomeAnnouncementsResponseDto.builder()
+                .totalPages(totalPages)
                 .totalCount(totalCount)
+                .hasNext(hasNext)
                 .result(announcements)
                 .build();
     }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -15,6 +15,5 @@ public interface InternshipRepositoryCustom {
 
     Page<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 
-    List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy);
-
+    Page<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, Pageable pageable);
 }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -142,7 +142,6 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
-
     private BooleanExpression getGraduatingFilter(User user){
         if(user.getFilter().getGrade() != Grade.SENIOR){
             return internshipAnnouncement.isGraduating.isFalse();

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -110,9 +110,9 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     }
 
     @Override
-    public List<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy){
-        return jpaQueryFactory
-                .select(internshipAnnouncement, scrap.id, scrap.color) // tuple -> Scrap 정보 한번에 불러오기
+    public Page<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, Pageable pageable) {
+        List<Tuple> content = jpaQueryFactory
+                .select(internshipAnnouncement, scrap.id, scrap.color)
                 .from(internshipAnnouncement)
                 .leftJoin(internshipAnnouncement.scraps, scrap).on(scrap.user.eq(user))
                 .where(
@@ -125,9 +125,24 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
                         sortAnnouncementsByDeadline().asc(),
                         getSortOrder(sortBy)
                 )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(internshipAnnouncement.count())
+                .from(internshipAnnouncement)
+                .where(
+                        getJobTypeFilter(user),
+                        getGraduatingFilter(user),
+                        getWorkingPeriodFilter(user),
+                        getStartDateFilter(user)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
-  
+
+
     private BooleanExpression getGraduatingFilter(User user){
         if(user.getFilter().getGrade() != Grade.SENIOR){
             return internshipAnnouncement.isGraduating.isFalse();

--- a/src/main/java/org/terning/terningserver/service/HomeService.java
+++ b/src/main/java/org/terning/terningserver/service/HomeService.java
@@ -1,8 +1,9 @@
 package org.terning.terningserver.service;
 
+import org.springframework.data.domain.Pageable;
 import org.terning.terningserver.dto.user.response.HomeAnnouncementsResponseDto;
 
 public interface HomeService {
 
-    HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy);
+    HomeAnnouncementsResponseDto getAnnouncements(Long userId, String sortBy, Pageable pageable);
 }


### PR DESCRIPTION
## 📄 Work Description

### 변경 사항

1. **공고 조회 API에 페이징 기능 추가**
   - `Pageable`을 활용하여 페이징 처리 구현.
   - `@PageableDefault` 어노테이션을 사용하여 기본 페이지 크기를 10으로 설정하여 유연한 페이징 요청 가능.

2. **DTO 수정**
   - `HomeAnnouncementsResponseDto`에 페이징 관련 필드 추가:
     - `totalPages`: 전체 페이지 수.
     - `hasNext`: 다음 페이지 존재 여부.

3. **Repository 수정**
   - 기존에 리스트로 반환하던 공고 데이터를 페이징 처리된 형태로 반환하도록 쿼리 수정.
   - `Page<Tuple>` 타입을 활용하여 페이징 로직을 구현하고, 데이터의 효율적 처리를 보장.
   - `JPAQueryFactory`를 사용하여 필터 조건을 기반으로 데이터를 페이징 처리하여 조회.

4. **Service 로직 리팩토링**
   - 중복된 로직과 책임을 분리하여 공통 메서드로 분리:
     - `getUserById`: 사용자 검증 및 조회 책임 분리.
     - `createEmptyResponse`: 데이터가 없을 경우 기본 응답을 생성.
   - DTO 매핑 로직 분리:
     - `mapToHomeResponseDtos`: 조회된 데이터를 DTO 형태로 변환하는 로직.
     - `isScrapped`, `determineColorValue`: 스크랩 여부 및 색상 처리 분리.
   - 페이징 결과 및 변환된 데이터를 포함한 최종 응답 생성 메서드 추가: `createResponse`.

5. **Swagger 수정**
   - 페이징 관련 파라미터(`page`, `size`)를 명시적으로 반영하여 API 문서 개선.
   - `sortBy` 파라미터와 함께 페이징 처리 내용을 API 명세에 포함.

---

## ⚙️ ISSUE

- closed #185

---

## 📷 Screenshot

![스크린샷 2024-12-20 오후 5 01 25](https://github.com/user-attachments/assets/d41e278b-39f4-4058-912c-6fd5be65035c)

---

## 💬 To Reviewers

- 이번 변경사항에서는 **페이징 처리**를 중심으로 서비스 로직과 관련된 모든 계층(HomeController, Service, Repository)을 수정하였습니다.
- 특히, 서비스 계층에서는 다음과 같은 역할과 책임 분리에 중점을 두고 메서드를 리팩토링하였습니다:
  - `getUserById`: 사용자 정보 검증 및 조회를 담당합니다.
  - `createEmptyResponse`: 데이터가 없는 경우 기본 응답을 생성합니다.
  - `mapToHomeResponseDtos`: DB에서 조회한 데이터를 DTO로 매핑합니다.
  - `isScrapped`, `determineColorValue`: 스크랩 여부와 색상 값을 분리하여 처리합니다.
  - `createResponse`: 페이징 결과를 포함한 최종 응답을 생성합니다.

- **테스트 코드 작성**에서는 Mocking이 많이 필요하여 어려움을 겪었습니다. 특히, `HomeServiceImpl`에서 데이터베이스 및 사용자 관련 작업들이 많아 Mock 객체를 구성하는 데 많은 시간이 소요되었습니다.
- Swagger나 Postman을 사용하지 않고 테스트 코드를 통해 검증하려 했으나, 코드가 테스트 작성에 최적화되어 있지 않아 개선의 필요성을 느꼈습니다.

### 🚀 개선 제안

- 최근 참석했던 **이동욱(인프런 CTO)님 테스트 코드 세미나**에서 배운 내용을 기반으로, 팀과 공유하여 **테스트 작성이 용이한 코드 구조**를 도입해보고 싶습니다.
- 테스트를 쉽게 작성할 수 있도록 **서비스 로직과 데이터 접근 로직을 더욱 명확히 분리**하고, Mocking 의존성을 줄일 수 있는 구조로 개선할 계획입니다.

### 🙏 리뷰어님께

- 코드 가독성 및 페이징 로직 최적화에 대해 보완점이나 개선할 부분이 있다면 언제든 말씀 부탁드립니다.
- 더불어, 테스트 코드 작성 방안이나 좋은 사례가 있다면 추천 부탁드립니다! 🙇

---

## 🔗 Reference
- [[Spring Pageable 사용 가이드](https://spring.io/guides)](https://spring.io/guides)](https://spring.io/guides)