### PR TITLE
[🔥 !hotfix] 필터링 정보가 모두 null이면 전체 공고가 보이도록 수정

### DIFF
--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryCustom.java
@@ -16,4 +16,6 @@ public interface InternshipRepositoryCustom {
     Page<InternshipAnnouncement> searchInternshipAnnouncement(String keyword, String sortBy, Pageable pageable);
 
     Page<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, Pageable pageable);
+
+    Page<Tuple> findAllInternshipsWithScrapInfo(User user, String sortBy, Pageable pageable);
 }

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -110,6 +110,27 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     }
 
     @Override
+    public Page<Tuple> findAllInternshipsWithScrapInfo(User user, String sortBy, Pageable pageable) {
+        List<Tuple> content = jpaQueryFactory
+                .select(internshipAnnouncement, scrap.id, scrap.color)
+                .from(internshipAnnouncement)
+                .leftJoin(internshipAnnouncement.scraps, scrap).on(scrap.user.eq(user))
+                .orderBy(
+                        sortAnnouncementsByDeadline().asc(),
+                        getSortOrder(sortBy)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(internshipAnnouncement.count())
+                .from(internshipAnnouncement);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
     public Page<Tuple> findFilteredInternshipsWithScrapInfo(User user, String sortBy, Pageable pageable) {
         List<Tuple> content = jpaQueryFactory
                 .select(internshipAnnouncement, scrap.id, scrap.color)


### PR DESCRIPTION
# 📄 Work Description
- [🔥 !hotfix] 필터링 정보가 모두 null이면 전체 공고가 보이도록 수정

# ⚙️ ISSUE
- closed #191 


# 📷 Screenshot
<img width="1415" alt="image" src="https://github.com/user-attachments/assets/1ada8412-c065-4c6c-b7a9-ac985a198b21" />
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/6bff0e0f-19a0-4aca-b9e8-e7fbd6149731" />

