### PR TITLE
[🔀 merge] [3차] 코드 리펙토링 사항 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
+//	implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
 
 	// Gson
 	implementation 'com.google.code.gson:gson:2.8.6'

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepositoryImpl.java
@@ -164,13 +164,15 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     }
 
     private BooleanExpression getGraduatingFilter(User user){
-        if(user.getFilter().getGrade() != Grade.SENIOR){
-            return internshipAnnouncement.isGraduating.isFalse();
+        if(user.getFilter().getGrade() == null) return null;
+        if(user.getFilter().getGrade() == Grade.SENIOR){
+            return internshipAnnouncement.isGraduating.isTrue();
         }
-        return null;
+        return internshipAnnouncement.isGraduating.isFalse();
     }
 
     private BooleanExpression getWorkingPeriodFilter(User user){
+        if(user.getFilter().getWorkingPeriod() == null) return null;
         if(user.getFilter().getWorkingPeriod() == WorkingPeriod.OPTION1){
             return getWorkingPeriodAsNumber().between(1,3);
         } else if(user.getFilter().getWorkingPeriod() == WorkingPeriod.OPTION2){
@@ -183,6 +185,8 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     private BooleanExpression getStartDateFilter(User user){
         int startYear = user.getFilter().getStartYear();
         int startMonth = user.getFilter().getStartMonth();
+
+        if(startYear == 0 || startMonth == 0) return null;
         return internshipAnnouncement.startYear.eq(startYear)
                 .and(internshipAnnouncement.startMonth.eq(startMonth));
     }
@@ -238,7 +242,7 @@ public class InternshipRepositoryImpl implements InternshipRepositoryCustom {
     }
 
     private BooleanExpression getJobTypeFilter(User user) {
-        if (user.getFilter().getJobType() == JobType.TOTAL) {
+        if (user.getFilter().getJobType() == null || user.getFilter().getJobType() == JobType.TOTAL) {
             return null; // total일 경우 모든 직무 공고 허용
         }
         return internshipAnnouncement.jobType.eq(user.getFilter().getJobType().getValue());


### PR DESCRIPTION
# 📄 Work Description
- 필터링 건너뛰기 시 직무 필터링만 적용되도록 데이터 반환 로직 수정
  - jobType만 설정되어 있는 경우에도 해당 직무 공고가 정상적으로 표시될 수 있도록 필터 로직을 수정
  - 핵심은 필드별로 null 혹은 기본값(0 등)일 때는 해당 필터 조건을 건너뛰도록 구현해야한다.

# ⚙️ ISSUE
- closed #193 


# 📷 Screenshot
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/2f271664-c65c-48aa-a857-bcef6938c748" />
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/c7bd7c12-842f-4e1c-886e-3a1700260e92" />
