### PR TITLE
[✨ feat] 소셜 로그인 시 FCM 토큰 검증 및 재발급 여부 응답 처리 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,14 @@ dependencies {
 
 	// Gson
 	implementation 'com.google.code.gson:gson:2.8.6'
+
+	// Spring WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Resilience4j
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
+	implementation 'io.github.resilience4j:resilience4j-reactor:2.1.0'
+
 }
 
 //QueryDSL 초기 설정

--- a/src/main/java/org/terning/terningserver/auth/dto/response/SignInResponse.java
+++ b/src/main/java/org/terning/terningserver/auth/dto/response/SignInResponse.java
@@ -10,15 +10,17 @@ public record SignInResponse(
         String refreshToken,
         Long userId,
         String authId,
-        AuthType authType
+        AuthType authType,
+        boolean fcmTokenReissueRequired
 ) {
-    public static SignInResponse of(Token token, String authId, AuthType authType, Long userId) {
+    public static SignInResponse of(Token token, String authId, AuthType authType, Long userId, boolean fcmTokenReissueRequired) {
         return new SignInResponse(
                 Optional.ofNullable(token).map(Token::getAccessToken).orElse(null),
                 Optional.ofNullable(token).map(Token::getRefreshToken).orElse(null),
                 userId,
                 authId,
-                authType
+                authType,
+                fcmTokenReissueRequired
         );
     }
 }

--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -10,7 +10,7 @@ public enum ErrorMessage {
     // 소셜 로그인
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다"),
     INVALID_KEY(401, "유효하지 않은 키입니다"),
-    FAILED_SOCIAL_LOGIN(404, "소셜 로그인애 실패하였습니다"),
+    FAILED_SOCIAL_LOGIN(404, "소셜 로그인에 실패하였습니다"),
     INVALID_USER(404, "유효하지 않은 유저입니다"),
     FAILED_TOKEN_REISSUE(404, "토큰 재발급에 실패하였습니다"),
     UNAUTHORIZED_JWT_EXCEPTION(401, "유효하지 않은 토큰입니다"),

--- a/src/main/java/org/terning/terningserver/external/config/WebClientConfig.java
+++ b/src/main/java/org/terning/terningserver/external/config/WebClientConfig.java
@@ -1,0 +1,48 @@
+package org.terning.terningserver.external.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 2000;
+    private static final int READ_TIMEOUT_SECONDS = 2;
+    private static final int WRITE_TIMEOUT_SECONDS = 2;
+
+    private static final String DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_JSON_VALUE;
+
+    @Value("${notification.base-url}")
+    private String notificationBaseUrl;
+
+    @Bean
+    public WebClient notificationWebClient() {
+        TcpClient tcpClient = TcpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                );
+
+        HttpClient httpClient = HttpClient.from(tcpClient);
+
+        return WebClient.builder()
+                .baseUrl(notificationBaseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, DEFAULT_CONTENT_TYPE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}
+

--- a/src/main/java/org/terning/terningserver/external/dto/FcmTokenReissueRequiredResponse.java
+++ b/src/main/java/org/terning/terningserver/external/dto/FcmTokenReissueRequiredResponse.java
@@ -1,0 +1,7 @@
+package org.terning.terningserver.external.dto;
+
+public record FcmTokenReissueRequiredResponse(boolean reissueRequired) {
+    public static FcmTokenReissueRequiredResponse of(boolean reissueRequired) {
+        return new FcmTokenReissueRequiredResponse(reissueRequired);
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/notification/FcmTokenValidationClient.java
+++ b/src/main/java/org/terning/terningserver/external/notification/FcmTokenValidationClient.java
@@ -1,0 +1,37 @@
+package org.terning.terningserver.external.notification;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.terning.terningserver.external.dto.FcmTokenReissueRequiredResponse;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class FcmTokenValidationClient {
+
+    private static final String FCM_VALIDATION_PATH = "/api/v1/users/{userId}/fcm-tokens/reissue-required";
+    private static final String FAIL_LOG = "FCM 토큰 유효성 검사 요청 실패";
+    private static final String FAIL_LOG_FALLBACK = FAIL_LOG + " (fallback) - userId: {}";
+
+    private final WebClient notificationWebClient;
+
+    @CircuitBreaker(name = "fcmValidation", fallbackMethod = "fallback")
+    public boolean requestFcmTokenValidation(Long userId) {
+        FcmTokenReissueRequiredResponse response = notificationWebClient.get()
+                .uri(FCM_VALIDATION_PATH, userId)
+                .retrieve()
+                .bodyToMono(FcmTokenReissueRequiredResponse.class)
+                .block();
+
+        return response != null && response.reissueRequired();
+    }
+
+    public boolean fallback(Long userId, Throwable t) {
+        log.warn(FAIL_LOG_FALLBACK, userId, t);
+        return false;
+    }
+}
+


### PR DESCRIPTION
# 📄 Work Description  
- 소셜 로그인 시, 해당 유저의 FCM 토큰 유효성을 확인하는 로직을 추가했습니다.  
- 외부 FCM 서버의 토큰 검증 API와 통신하기 위해 `WebClient` 설정(`WebClientConfig`)을 구성했습니다.  
- `FcmTokenValidationClient`를 통해 API 호출 및 결과를 받아오며, `Resilience4j Circuit Breaker`를 적용해 장애 상황에 대한 대응도 고려했습니다.  
- 로그인 응답인 `SignInResponse`에 `fcmTokenReissueRequired` 필드를 추가해서, 클라이언트가 재발금 필요 여부를 판단할 수 있도록 하였습니다.  
- 이로서 클라이언트는 로그인 응답을 통해 FCM 토큰 재발금이 필요한지 여부를 판단하고 필요한 대응을 합니다.

# 💬 To Reviewers  
- 로그인 프로세스에 외부 API 호출이 추가되며 네트웨크 이슈나 장애 상황도 고려하게 되어 `CircuitBreaker`를 적용했습니다.  
- 현재는 fallback 시 단순히 `false`를 반환하고 있는데, 이 처리 방식이 적절한지 함께 고민해보면 좋을 것 같습니다.    
- 필드가 늘어난 만큼, 명확하게 활용되도록 API 문서에 반영하겠습니다!

# 📷 Screenshot  
![스크린샷 2025-03-29 오후 5 05 53](https://github.com/user-attachments/assets/1a898368-2e4b-42b3-b8c0-4995f8533e64)


# ⚙️ ISSUE  
- closed #210 