### PR TITLE
[✨ feat] 스크랩한 유저를 조회하는 API 구현 

### DIFF
--- a/src/main/java/org/terning/terningserver/config/SecurityConfig.java
+++ b/src/main/java/org/terning/terningserver/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/swagger-ui/**",
             "/api/v1/auth/**",
-            "/actuator/health"
+            "/actuator/health",
+            "/api/v1/external/scraps/unsynced"
     };
 
     @Bean

--- a/src/main/java/org/terning/terningserver/domain/Scrap.java
+++ b/src/main/java/org/terning/terningserver/domain/Scrap.java
@@ -1,13 +1,11 @@
 package org.terning.terningserver.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.terning.terningserver.domain.common.BaseTimeEntity;
 import org.terning.terningserver.domain.enums.Color;
-
-import java.awt.*;
+import org.terning.terningserver.domain.vo.SyncStatus;
 
 import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
@@ -21,40 +19,45 @@ public class Scrap extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    private Long id; // 스크랩 고유 ID
+    private Long id;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private User user; // 스크랩한 사용자
+    private User user;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "internship_announcement_id", nullable = false)
-    private InternshipAnnouncement internshipAnnouncement; // 스크랩한 인턴십 공고
+    private InternshipAnnouncement internshipAnnouncement;
 
     @Enumerated(STRING)
     @Column(nullable = false)
-    private Color color; // 스크랩 색상 (사용자가 지정)
+    private Color color;
 
-    @Builder
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "synced", nullable = false))
+    private SyncStatus syncStatus;
+
     private Scrap(User user, InternshipAnnouncement internshipAnnouncement, Color color) {
         this.user = user;
         this.internshipAnnouncement = internshipAnnouncement;
         this.color = color;
+        this.syncStatus = SyncStatus.notSynced();
     }
 
     public static Scrap create(User user, InternshipAnnouncement internshipAnnouncement, Color color) {
-        return Scrap.builder()
-                .user(user)
-                .internshipAnnouncement(internshipAnnouncement)
-                .color(color)
-                .build();
+        return new Scrap(user, internshipAnnouncement, color);
     }
 
     public void updateColor(Color color) {
         this.color = color;
     }
 
-    public String getColorToHexValue(){
+    public String getColorToHexValue() {
         return this.color.getColorValue();
     }
+
+    public void markSynced() {
+        this.syncStatus = SyncStatus.synced();
+    }
 }
+

--- a/src/main/java/org/terning/terningserver/domain/vo/SyncStatus.java
+++ b/src/main/java/org/terning/terningserver/domain/vo/SyncStatus.java
@@ -1,0 +1,35 @@
+package org.terning.terningserver.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+
+@Embeddable
+@EqualsAndHashCode
+public class SyncStatus {
+
+    private boolean value;
+
+    protected SyncStatus() {
+    }
+
+    private SyncStatus(boolean value) {
+        this.value = value;
+    }
+
+    public static SyncStatus notSynced() {
+        return new SyncStatus(false);
+    }
+
+    public static SyncStatus synced() {
+        return new SyncStatus(true);
+    }
+
+    public boolean isSynced() {
+        return value;
+    }
+
+    public boolean isNotSynced() {
+        return !value;
+    }
+}
+

--- a/src/main/java/org/terning/terningserver/external/scrap/api/ScrapExternalApiController.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/api/ScrapExternalApiController.java
@@ -1,0 +1,23 @@
+package org.terning.terningserver.external.scrap.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.terning.terningserver.external.scrap.application.ScrapExternalService;
+import org.terning.terningserver.external.scrap.dto.response.UnsyncedScrapUsersResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/external/scraps")
+public class ScrapExternalApiController {
+
+    private final ScrapExternalService scrapExternalService;
+
+    @GetMapping("/unsynced")
+    public ResponseEntity<UnsyncedScrapUsersResponse> fetchUnsyncedScrapUsers() {
+        UnsyncedScrapUsersResponse response = scrapExternalService.fetchUnsyncedScrapUsers();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/scrap/application/ScrapExternalService.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/application/ScrapExternalService.java
@@ -1,0 +1,17 @@
+package org.terning.terningserver.external.scrap.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.terning.terningserver.external.scrap.dto.response.UnsyncedScrapUsersResponse;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapExternalService {
+
+    private final UnsyncedScrapUserReader unsyncedScrapUserReader;
+
+    public UnsyncedScrapUsersResponse fetchUnsyncedScrapUsers() {
+        return unsyncedScrapUserReader.readUnsyncedScrapUsers();
+    }
+}
+

--- a/src/main/java/org/terning/terningserver/external/scrap/application/UnsyncedScrapUserReader.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/application/UnsyncedScrapUserReader.java
@@ -1,0 +1,7 @@
+package org.terning.terningserver.external.scrap.application;
+
+import org.terning.terningserver.external.scrap.dto.response.UnsyncedScrapUsersResponse;
+
+public interface UnsyncedScrapUserReader {
+    UnsyncedScrapUsersResponse readUnsyncedScrapUsers();
+}

--- a/src/main/java/org/terning/terningserver/external/scrap/application/UnsyncedScrapUserReaderImpl.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/application/UnsyncedScrapUserReaderImpl.java
@@ -1,0 +1,22 @@
+package org.terning.terningserver.external.scrap.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.terning.terningserver.external.scrap.dto.response.UnsyncedScrapUsersResponse;
+import org.terning.terningserver.repository.scrap.ScrapRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UnsyncedScrapUserReaderImpl implements UnsyncedScrapUserReader {
+
+    private final ScrapRepository scrapRepository;
+
+    @Override
+    public UnsyncedScrapUsersResponse readUnsyncedScrapUsers() {
+        List<Long> userIds = scrapRepository.findUserIdsWithUnsyncedScraps();
+        return UnsyncedScrapUsersResponse.of(userIds);
+    }
+
+}

--- a/src/main/java/org/terning/terningserver/external/scrap/dto/response/UnsyncedScrapUserResponse.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/dto/response/UnsyncedScrapUserResponse.java
@@ -1,0 +1,7 @@
+package org.terning.terningserver.external.scrap.dto.response;
+
+public record UnsyncedScrapUserResponse(Long userId) {
+    public static UnsyncedScrapUserResponse from(Long userId) {
+        return new UnsyncedScrapUserResponse(userId);
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/scrap/dto/response/UnsyncedScrapUsersResponse.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/dto/response/UnsyncedScrapUsersResponse.java
@@ -1,0 +1,14 @@
+package org.terning.terningserver.external.scrap.dto.response;
+
+import java.util.List;
+
+public record UnsyncedScrapUsersResponse(List<UnsyncedScrapUserResponse> users) {
+
+    public static UnsyncedScrapUsersResponse of(List<Long> userIds) {
+        List<UnsyncedScrapUserResponse> responses = userIds.stream()
+                .map(UnsyncedScrapUserResponse::from)
+                .toList();
+
+        return new UnsyncedScrapUsersResponse(responses);
+    }
+}

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepository.java
@@ -3,8 +3,6 @@ package org.terning.terningserver.repository.scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.terning.terningserver.domain.Scrap;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapRepositoryCustom {
@@ -15,6 +13,5 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
     void deleteByInternshipAnnouncementIdAndUserId(Long internshipId, Long userId);
 
     boolean existsByUserId(Long userId);
-
 }
 

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryCustom.java
@@ -17,4 +17,5 @@ public interface ScrapRepositoryCustom {
 
     String findColorByInternshipAnnouncementIdAndUserId(Long internshipAnnouncementId, Long userId);
 
+    List<Long> findUserIdsWithUnsyncedScraps();
 }

--- a/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/terningserver/repository/scrap/ScrapRepositoryImpl.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import static org.terning.terningserver.domain.QScrap.scrap;
 
-
 @RequiredArgsConstructor
 public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
 
@@ -63,5 +62,15 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
                 .fetchOne();
 
         return foundScrap != null ? foundScrap.getColorToHexValue() : null;
+    }
+
+    @Override
+    public List<Long> findUserIdsWithUnsyncedScraps() {
+        return jpaQueryFactory
+                .select(scrap.user.id)
+                .from(scrap)
+                .where(scrap.syncStatus.value.eq(false))
+                .distinct()
+                .fetch();
     }
 }


### PR DESCRIPTION
# 📄 Work Description

- 알림 서버와의 스크랩 동기화를 위해, 동기화되지 않은 스크랩을 가진 유저 목록을 조회하는 API를 구현하였습니다.
- `Scrap` 도메인에 `syncStatus` 임베디드 VO를 추가하여 동기화 여부를 명확히 표현했습니다.
- `/api/v1/external/scraps/unsynced` 경로로 외부에서 접근 가능한 조회 API를 제공하며, 인증 필터에서 해당 경로를 제외 처리하였습니다.
- `UnsyncedScrapUserReader` 인터페이스와 구현체(`UnsyncedScrapUserReaderImpl`)를 통해 조회 책임을 분리하고, 테스트 용이성과 확장성을 고려했습니다.
- DTO (`UnsyncedScrapUserResponse`, `UnsyncedScrapUsersResponse`)를 통해 API 응답 구조를 명확히 구성했습니다.

# 💬 To Reviewers
- 이번 작업에서 `Scrap`, `SyncStatus`, `UnsyncedScrapUserReader`와 같은 네이밍이 직관적인지 고민이 많았습니다.  
- 특히, `SyncStatus`가 boolean을 감싸고 있어 단순해 보일 수도 있는데, 도메인 표현으로 적절한지 의견을 듣고 싶습니다.  
- 또 `UnsyncedScrapUserReaderImpl`이라는 이름이 너무 길진 않은지도 피드백 부탁드립니다!  
- 네이밍 외에도 개선할 점 있다면 편하게 말씀해 주세요!
- 테스트 코드는 작성하려 했으나, 기존 코드의 의존관계가 복잡해 바로 도입하기 어려운 상황이라  
이번 스프린트 종료 후 구조 개선과 함께 적용해보려고 합니다. 양해 부탁드립니다 🙏

# 📷 Screenshot
![스크린샷 2025-03-30 오후 7 04 30](https://github.com/user-attachments/assets/a0a77fba-d2ad-4da5-9bd8-66cf40f2c23b)


# ⚙️ ISSUE
- closed #213 