### PR TITLE
[✨ feat] 회원가입 시 FCM 토큰 저장 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,14 @@ dependencies {
 
 	// Gson
 	implementation 'com.google.code.gson:gson:2.8.6'
+
+	// Spring WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Resilience4j
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
+	implementation 'io.github.resilience4j:resilience4j-reactor:2.1.0'
+
 }
 
 //QueryDSL 초기 설정

--- a/src/main/java/org/terning/terningserver/auth/application/signup/AuthSignUpServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/auth/application/signup/AuthSignUpServiceImpl.java
@@ -9,6 +9,7 @@ import org.terning.terningserver.domain.enums.Grade;
 import org.terning.terningserver.domain.enums.JobType;
 import org.terning.terningserver.domain.enums.ProfileImage;
 import org.terning.terningserver.domain.enums.WorkingPeriod;
+import org.terning.terningserver.external.notification.NotificationUserClient;
 import org.terning.terningserver.jwt.application.JwtTokenManager;
 import org.terning.terningserver.domain.Filter;
 import org.terning.terningserver.domain.Token;
@@ -32,6 +33,7 @@ public class AuthSignUpServiceImpl implements AuthSignUpService {
     private final UserRepository userRepository;
     private final FilterRepository filterRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final NotificationUserClient notificationUserClient;
 
     @Transactional
     @Override
@@ -43,6 +45,12 @@ public class AuthSignUpServiceImpl implements AuthSignUpService {
         user.updateRefreshToken(token.getRefreshToken());
         eventPublisher.publishEvent(UserSignedUpEvent.of(user));
 
+        notificationUserClient.createUserOnNotificationServer(
+                user.getId(),
+                user.getName(),
+                user.getAuthType(),
+                request.fcmToken()
+        );
 
         return createSignUpResponseDto(token, user);
     }

--- a/src/main/java/org/terning/terningserver/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/org/terning/terningserver/auth/dto/request/SignUpRequestDto.java
@@ -10,14 +10,16 @@ import static lombok.AccessLevel.PRIVATE;
 public record SignUpRequestDto(
         @NonNull String name,
         String profileImage,
-        @NonNull AuthType authType
+        @NonNull AuthType authType,
+        String fcmToken
 ) {
 
-        public static SignUpRequestDto of(String name, String profileImage, AuthType authType){
+        public static SignUpRequestDto of(String name, String profileImage, AuthType authType, String fcmToken){
             return SignUpRequestDto.builder()
                     .name(name)
                     .profileImage(profileImage)
                     .authType(authType)
+                    .fcmToken(fcmToken)
                     .build();
         }
 

--- a/src/main/java/org/terning/terningserver/external/config/WebClientConfig.java
+++ b/src/main/java/org/terning/terningserver/external/config/WebClientConfig.java
@@ -1,0 +1,47 @@
+package org.terning.terningserver.external.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 2000;
+    private static final int READ_TIMEOUT_SECONDS = 2;
+    private static final int WRITE_TIMEOUT_SECONDS = 2;
+
+    private static final String DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_JSON_VALUE;
+
+    @Value("${notification.base-url}")
+    private String notificationBaseUrl;
+
+    @Bean
+    public WebClient notificationWebClient() {
+        TcpClient tcpClient = TcpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                );
+
+        HttpClient httpClient = HttpClient.from(tcpClient);
+
+        return WebClient.builder()
+                .baseUrl(notificationBaseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, DEFAULT_CONTENT_TYPE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/dto/request/CreateUserRequest.java
+++ b/src/main/java/org/terning/terningserver/external/dto/request/CreateUserRequest.java
@@ -1,0 +1,13 @@
+package org.terning.terningserver.external.dto.request;
+
+import org.terning.terningserver.domain.enums.AuthType;
+
+public record CreateUserRequest(
+        Long userId,
+        String name,
+        AuthType authType,
+        String fcmToken,
+        String pushStatus,
+        String accountStatus
+) {
+}

--- a/src/main/java/org/terning/terningserver/external/dto/request/CreateUserRequest.java
+++ b/src/main/java/org/terning/terningserver/external/dto/request/CreateUserRequest.java
@@ -1,8 +1,10 @@
 package org.terning.terningserver.external.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.terning.terningserver.domain.enums.AuthType;
 
 public record CreateUserRequest(
+        @JsonProperty("oUserId")
         Long userId,
         String name,
         AuthType authType,

--- a/src/main/java/org/terning/terningserver/external/notification/NotificationUserClient.java
+++ b/src/main/java/org/terning/terningserver/external/notification/NotificationUserClient.java
@@ -1,0 +1,53 @@
+package org.terning.terningserver.external.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.terning.terningserver.domain.enums.AuthType;
+import org.terning.terningserver.external.dto.request.CreateUserRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationUserClient {
+
+    private final WebClient notificationWebClient;
+
+    /**
+     * 알림서버에 신규 사용자 정보를 전달하여 사용자 레코드를 생성합니다.
+     * 운영서버에서는 FCM 토큰을 DB에 저장하지 않고,
+     * 기본값으로 pushStatus="enabled"와 accountStatus="active"를 전달합니다.
+     *
+     * @param userId    신규 사용자 ID
+     * @param name      사용자 이름
+     * @param authType  인증 타입 (문자열, 예: "kakao", "apple")
+     * @param fcmToken  클라이언트로부터 받은 FCM 토큰
+     */
+    public void createUserOnNotificationServer(
+            Long userId,
+            String name,
+            AuthType authType,
+            String fcmToken
+    ) {
+        CreateUserRequest request = new CreateUserRequest(
+                userId,
+                name,
+                authType,
+                fcmToken,
+                "enabled",
+                "active"
+        );
+
+        notificationWebClient.post()
+                .uri("/api/v1/users")
+                .body(Mono.just(request), CreateUserRequest.class)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+
+        log.info("User (id={}) created on notification server : ", userId);
+    }
+
+}


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #212 

# 📄 Work Description
운영서버에서 회원가입 시 회원 정보를 dto에 담아 알림서버의 user에 새롭게 추가하도록 구현했어요!
운영서버에서의 유저 id는 알림서버의 oUserId로써 함께 가지고 있을 수 있도록 구현했어요 :)
그리고 알림서버에서의 특정 컬럼은 회원가입 시 기본값으로 초기화 되도록 했어요.

push_status (푸시알림 설정 여부)  > `ENABLED`
account_status (해당 유저의 로그인 여부) > `ACTIVE`

그리고 해당 방식이 동기적으로 구현이 이루어지다보니 아무래도 트래픽이 많이 몰리는 상황에서는 비효율적이라는 생각이 들었어요.
이후 구현할때 메시지 큐를 이용해 비동기적으로 처리하는 것을 고려해보면 좋을 것 같아요..!

### 해당 내용은 알림 서버의 PR에도 중복되는 내용이 많아 코드의 양은 적게 반영되어 있을 수 있습니다 :)

# 📷 Screenshot
### 운영서버에서 회원가입 진행
<img width="685" alt="image" src="https://github.com/user-attachments/assets/d7fe6e5e-c0e7-449f-93a0-4a848b42b080" />
<img width="448" alt="image" src="https://github.com/user-attachments/assets/46586b5a-149c-47d5-bb08-653d29f755d2" />

### 알림서버의 DB에 해당 정보 정상적으로 저장 (운영서버 userId == 알림서버 oUserId)
<img width="992" alt="image" src="https://github.com/user-attachments/assets/525e1c44-156e-44cc-bf8c-42ff3afc9ecf" />



# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels