### PR TITLE
[✨ feat] 유저 상태(푸시알림 허용 여부, 유저 이름 변경, 회원 탈퇴) 시 알림서버 <> 운영서버 동기화 작업 및 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
 	implementation 'io.github.resilience4j:resilience4j-reactor:2.1.0'
 
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+
 }
 
 //QueryDSL 초기 설정

--- a/src/main/java/org/terning/terningserver/TerningserverApplication.java
+++ b/src/main/java/org/terning/terningserver/TerningserverApplication.java
@@ -3,9 +3,11 @@ package org.terning.terningserver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 public class TerningserverApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/terning/terningserver/config/SecurityConfig.java
+++ b/src/main/java/org/terning/terningserver/config/SecurityConfig.java
@@ -27,6 +27,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/api/v1/auth/**",
             "/actuator/health",
+            "/api/v1/users/**",
+            "/api/v1/push-status",
             "/api/v1/external/scraps/unsynced",
             "/api/v1/external/scraps/sync/result"
     };

--- a/src/main/java/org/terning/terningserver/controller/UserProfileController.java
+++ b/src/main/java/org/terning/terningserver/controller/UserProfileController.java
@@ -1,14 +1,16 @@
 package org.terning.terningserver.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.controller.swagger.UserSwagger;
 import org.terning.terningserver.dto.user.request.ProfileUpdateRequestDto;
+import org.terning.terningserver.dto.user.request.PushStatusUpdateRequest;
 import org.terning.terningserver.dto.user.response.ProfileResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
+import org.terning.terningserver.exception.enums.SuccessMessage;
+import org.terning.terningserver.external.notification.NotificationUserClient;
 import org.terning.terningserver.service.UserService;
 
 import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_GET_PROFILE;
@@ -20,6 +22,7 @@ import static org.terning.terningserver.exception.enums.SuccessMessage.SUCCESS_U
 public class UserProfileController implements UserSwagger {
 
     private final UserService userService;
+    private final NotificationUserClient notificationUserClient;
 
     @GetMapping("/mypage/profile")
     public ResponseEntity<SuccessResponse<ProfileResponseDto>> getProfile(
@@ -36,5 +39,19 @@ public class UserProfileController implements UserSwagger {
     ){
         userService.updateProfile(userId, request);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_PROFILE));
+    }
+
+    @PatchMapping("/push-status")
+    public ResponseEntity<SuccessResponse<Void>> updatePushStatus(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody PushStatusUpdateRequest request
+    ) {
+        // 운영서버에서 User 엔티티 업데이트
+        userService.updatePushStatus(userId, request.newStatus());
+
+        // 알림서버에 변경사항 동기화
+        notificationUserClient.updatePushStatus(userId, request.newStatus());
+
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.PUSH_STATUS_UPDATED));
     }
 }

--- a/src/main/java/org/terning/terningserver/controller/swagger/UserSwagger.java
+++ b/src/main/java/org/terning/terningserver/controller/swagger/UserSwagger.java
@@ -3,7 +3,11 @@ package org.terning.terningserver.controller.swagger;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.terning.terningserver.dto.user.request.ProfileUpdateRequestDto;
+import org.terning.terningserver.dto.user.request.PushStatusUpdateRequest;
 import org.terning.terningserver.dto.user.response.ProfileResponseDto;
 import org.terning.terningserver.exception.dto.SuccessResponse;
 
@@ -19,6 +23,12 @@ public interface UserSwagger {
     ResponseEntity<SuccessResponse> updateProfile(
             Long userId,
             ProfileUpdateRequestDto request
+    );
+
+    @Operation(summary = "마이페이지 > 푸시알림 상태 변경하기", description = "마이페이지에서 푸시알림 허용 여부를 수정하는 API")
+    ResponseEntity<SuccessResponse<Void>> updatePushStatus(
+            Long userId,
+            PushStatusUpdateRequest request
     );
 
 }

--- a/src/main/java/org/terning/terningserver/domain/User.java
+++ b/src/main/java/org/terning/terningserver/domain/User.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.terning.terningserver.domain.common.BaseTimeEntity;
 import org.terning.terningserver.domain.enums.AuthType;
 import org.terning.terningserver.domain.enums.ProfileImage;
+import org.terning.terningserver.domain.enums.PushNotificationStatus;
 import org.terning.terningserver.domain.enums.State;
 import org.terning.terningserver.exception.CustomException;
 
@@ -44,6 +45,10 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(STRING)
     private AuthType authType; // 인증 유형 (예: 카카오, 애플)
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    private PushNotificationStatus pushStatus;
 
     @Column(length = 256)
     private String authId; // 인증 서비스에서 제공하는 고유 ID

--- a/src/main/java/org/terning/terningserver/domain/enums/PushNotificationStatus.java
+++ b/src/main/java/org/terning/terningserver/domain/enums/PushNotificationStatus.java
@@ -1,0 +1,55 @@
+package org.terning.terningserver.domain.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.terning.terningserver.exception.CustomException;
+import org.terning.terningserver.exception.enums.ErrorMessage;
+
+import java.util.Arrays;
+
+public enum PushNotificationStatus {
+    ENABLED("enabled"),
+    DISABLED("disabled");
+
+    private final String value;
+
+    PushNotificationStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static PushNotificationStatus from(String input) {
+        return Arrays.stream(values())
+                .filter(status -> status.value.equalsIgnoreCase(input))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorMessage.INVALID_FORMAT_ERROR));
+    }
+
+    public static boolean isValid(String input) {
+        return Arrays.stream(values())
+                .anyMatch(status -> status.value.equalsIgnoreCase(input));
+    }
+
+    public boolean canReceiveNotification() {
+        return this == ENABLED;
+    }
+
+    public PushNotificationStatus enable() {
+        if (this == ENABLED) {
+            throw new CustomException(ErrorMessage.ALREADY_ENABLED_PUSH_NOTIFICATION);
+        }
+        return ENABLED;
+    }
+
+    public PushNotificationStatus disable() {
+        if (this == DISABLED) {
+            throw new CustomException(ErrorMessage.ALREADY_DISABLED_PUSH_NOTIFICATION);
+        }
+        return DISABLED;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/org/terning/terningserver/dto/user/request/PushStatusUpdateRequest.java
+++ b/src/main/java/org/terning/terningserver/dto/user/request/PushStatusUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.terning.terningserver.dto.user.request;
+
+public record PushStatusUpdateRequest(String newStatus) {
+    public static PushStatusUpdateRequest of(String newStatus) {
+        return new PushStatusUpdateRequest(newStatus);
+    }
+}

--- a/src/main/java/org/terning/terningserver/dto/user/response/ProfileResponseDto.java
+++ b/src/main/java/org/terning/terningserver/dto/user/response/ProfileResponseDto.java
@@ -7,13 +7,15 @@ import org.terning.terningserver.domain.User;
 public record ProfileResponseDto(
         String name,
         String profileImage,
-        String authType
+        String authType,
+        String pushStatus
 ) {
     public static ProfileResponseDto of(final User user){
         return ProfileResponseDto.builder()
                 .name(user.getName())
                 .profileImage(user.getProfileImage().getValue()) // Enum to String
                 .authType(user.getAuthType().name().toUpperCase())
+                .pushStatus(user.getPushStatus().value())
                 .build();
     }
 }

--- a/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/ErrorMessage.java
@@ -49,6 +49,8 @@ public enum ErrorMessage {
     ILLEGAL_ARGUMENT_ERROR( 400, "필수 파라미터가 없습니다"),
     INVALID_HTTP_METHOD( 400, "잘못된 Http Method 요청입니다."),
     INTERNAL_SERVER_ERROR( 500, "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    ALREADY_ENABLED_PUSH_NOTIFICATION(400, "이미 푸시 알림이 활성화되어 있습니다."),
+    ALREADY_DISABLED_PUSH_NOTIFICATION(400, "이미 푸시 알림이 비활성화되어 있습니다."),
     ;
 
 

--- a/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/exception/enums/SuccessMessage.java
@@ -54,7 +54,8 @@ public enum SuccessMessage {
 
     // My page (마이페이지 화면)
     SUCCESS_GET_PROFILE(200, "마이페이지 > 프로필 정보 불러오기를 성공했습니다"),
-    SUCCESS_UPDATE_PROFILE(200, "프로필 수정에 성공했습니다");
+    SUCCESS_UPDATE_PROFILE(200, "프로필 수정에 성공했습니다"),
+    PUSH_STATUS_UPDATED(200, "사용자 푸시알림 여부 변경을 완료했습니다.");
 
 
     private final int status;

--- a/src/main/java/org/terning/terningserver/external/notification/NotificationUserClient.java
+++ b/src/main/java/org/terning/terningserver/external/notification/NotificationUserClient.java
@@ -50,4 +50,56 @@ public class NotificationUserClient {
         log.info("User (id={}) created on notification server : ", userId);
     }
 
+    /**
+     * 알림서버에 신규 사용자 정보를 전달하여 사용자 레코드를 생성합니다.
+     * 운영서버에서는 pushStatus 값을 DB에 저장하지 않고,
+     * pushStatus="enabled" 또는 "disabled 로 변경합니다.
+     *
+     * @param userId         기존 사용자 ID
+     * @param newPushStatus  새로운 푸시알림 허용 여부
+     */
+    public void updatePushStatus(Long userId, String newPushStatus) {
+        notificationWebClient.put()
+                .uri("/api/v1/users/{userId}/push-status", userId)
+                .body(Mono.just(newPushStatus), String.class)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+
+        log.info("Push status updated for user (id={}): {}", userId, newPushStatus);
+    }
+
+    /**
+     * 프로필 정보를 변경하면, 알림서버에 새로운 사용자 이름을 전달하여 사용자 레코드를 변경합니다.
+     * 운영서버와 알림서버 모두 변경 값을 반영하도록 합니다.
+     *
+     * @param userId    기존 사용자 ID
+     * @param newName   변경된 새로운 사용자 이름
+     */
+    public void updateUserName(Long userId, String newName) {
+        notificationWebClient.put()
+                .uri("/api/v1/users/{userId}/name", userId)
+                .body(Mono.just(newName), String.class)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+
+        log.info("User name updated for user (id={}): {}", userId, newName);
+    }
+
+    /**
+     * 회원 탈퇴 시 알림서버에 존재하는 사용자를 삭제하여 사용자 레코드를 변경합니다.
+     * 운영서버와 알림서버 모두 해당 유저를 삭제하도록 합니다.
+     *
+     * @param userId    기존 사용자 ID
+     */
+    public void deleteUser(Long userId) {
+        notificationWebClient.delete()
+                .uri("/api/v1/users/{userId}", userId)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+
+        log.info("User (id={}) deleted on notification server.", userId);
+    }
 }

--- a/src/main/java/org/terning/terningserver/external/scrap/ScrapSyncMarkerImpl.java
+++ b/src/main/java/org/terning/terningserver/external/scrap/ScrapSyncMarkerImpl.java
@@ -1,4 +1,4 @@
-package org.terning.terningserver.external.scrap.application.service;
+package org.terning.terningserver.external.scrap;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/terning/terningserver/external/user/application/UserSyncEventService.java
+++ b/src/main/java/org/terning/terningserver/external/user/application/UserSyncEventService.java
@@ -1,0 +1,8 @@
+package org.terning.terningserver.external.user.application;
+
+
+public interface UserSyncEventService {
+
+    void recordNameChange(Long userId, String newName);
+    void recordWithdraw(Long userId);
+}

--- a/src/main/java/org/terning/terningserver/external/user/application/UserSyncEvnetServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/external/user/application/UserSyncEvnetServiceImpl.java
@@ -1,0 +1,50 @@
+package org.terning.terningserver.external.user.application;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.terning.terningserver.external.user.domain.UserSyncEvent;
+import org.terning.terningserver.external.user.domain.UserSyncEventType;
+import org.terning.terningserver.external.user.respository.UserSyncEventRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserSyncEvnetServiceImpl implements UserSyncEventService {
+
+    private final UserSyncEventRepository eventRepository;
+
+    @Transactional
+    public void recordPushStatusChange(Long userId, String newPushStatus) {
+        UserSyncEvent event = UserSyncEvent.builder()
+                .userId(userId)
+                .eventType(UserSyncEventType.PUSH_STATUS_CHANGE)
+                .newValue(newPushStatus)
+                .createdAt(LocalDateTime.now())
+                .build();
+        eventRepository.save(event);
+    }
+
+    @Transactional
+    public void recordNameChange(Long userId, String newName) {
+        UserSyncEvent event = UserSyncEvent.builder()
+                .userId(userId)
+                .eventType(UserSyncEventType.NAME_CHANGE)
+                .newValue(newName)
+                .createdAt(LocalDateTime.now())
+                .build();
+        eventRepository.save(event);
+    }
+
+    @Transactional
+    public void recordWithdraw(Long userId) {
+        UserSyncEvent event = UserSyncEvent.builder()
+                .userId(userId)
+                .eventType(UserSyncEventType.WITHDRAW)
+                .newValue(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+        eventRepository.save(event);
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/user/config/NotificationSyncTasklet.java
+++ b/src/main/java/org/terning/terningserver/external/user/config/NotificationSyncTasklet.java
@@ -1,0 +1,58 @@
+package org.terning.terningserver.external.user.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import org.terning.terningserver.external.notification.NotificationUserClient;
+import org.terning.terningserver.external.user.domain.UserSyncEvent;
+import org.terning.terningserver.external.user.respository.UserSyncEventRepository;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationSyncTasklet implements Tasklet {
+
+    private final UserSyncEventRepository eventRepository;
+    private final NotificationUserClient notificationUserClient;
+
+    private static final String NO_SYNC_EVENTS = "Unsync 상태의 유저 event가 없습니다.";
+    private static final String COMPLETED_SYNC_EVENTS = "유저 이벤트 동기화에 성공했습니다.";
+    private static final String FAILED_SYNC_EVENTS = "유저 이벤트 동기화에 성공했습니다.";
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        List<UserSyncEvent> events = eventRepository.findByProcessedFalse();
+        if (events.isEmpty()) {
+            log.info(NO_SYNC_EVENTS);
+            return RepeatStatus.FINISHED;
+        }
+
+        for (UserSyncEvent event : events) {
+            try {
+                Long userId = event.getUserId();
+                switch (event.getEventType()) {
+                    case PUSH_STATUS_CHANGE:
+                        notificationUserClient.updatePushStatus(userId, event.getNewValue());
+                        break;
+                    case NAME_CHANGE:
+                        notificationUserClient.updateUserName(userId, event.getNewValue());
+                        break;
+                    case WITHDRAW:
+                        notificationUserClient.deleteUser(userId);
+                        break;
+                }
+                event.markProcessed();
+                eventRepository.save(event);
+                log.info(COMPLETED_SYNC_EVENTS + " Id = " + event.getId() + " userId = " + event.getUserId());
+            } catch (Exception e) {
+                log.error(FAILED_SYNC_EVENTS + " Id = " + event.getId() + " userId = " + event.getUserId());
+            }
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/user/config/UserSyncJobConfig.java
+++ b/src/main/java/org/terning/terningserver/external/user/config/UserSyncJobConfig.java
@@ -1,0 +1,35 @@
+package org.terning.terningserver.external.user.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class UserSyncJobConfig {
+
+    public static final String USER_SYNC_JOB = "userSyncJob";
+    public static final String USER_SYNC_STEP = "userSyncStep";
+
+    private final NotificationSyncTasklet notificationSyncTasklet;
+
+    @Bean
+    public Job userSyncJob(JobRepository jobRepository, Step userSyncStep) {
+        return new JobBuilder(USER_SYNC_JOB, jobRepository)
+                .start(userSyncStep)
+                .build();
+    }
+
+    @Bean
+    public Step userSyncStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder(USER_SYNC_STEP, jobRepository)
+                .tasklet(notificationSyncTasklet, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/user/domain/UserSyncEvent.java
+++ b/src/main/java/org/terning/terningserver/external/user/domain/UserSyncEvent.java
@@ -1,0 +1,48 @@
+package org.terning.terningserver.external.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_sync_events")
+public class UserSyncEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @Enumerated
+    private UserSyncEventType eventType;
+
+    private String newValue;
+
+    private LocalDateTime createdAt;
+
+    private boolean processed;
+
+    @Builder
+    public UserSyncEvent(Long userId, UserSyncEventType eventType, String newValue, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.eventType = eventType;
+        this.newValue = newValue;
+        this.createdAt = createdAt;
+        this.processed = false;
+    }
+
+    public void markProcessed() {
+        this.processed = true;
+    }
+}

--- a/src/main/java/org/terning/terningserver/external/user/domain/UserSyncEventType.java
+++ b/src/main/java/org/terning/terningserver/external/user/domain/UserSyncEventType.java
@@ -1,0 +1,7 @@
+package org.terning.terningserver.external.user.domain;
+
+public enum UserSyncEventType {
+    PUSH_STATUS_CHANGE,
+    NAME_CHANGE,
+    WITHDRAW
+}

--- a/src/main/java/org/terning/terningserver/external/user/respository/UserSyncEventRepository.java
+++ b/src/main/java/org/terning/terningserver/external/user/respository/UserSyncEventRepository.java
@@ -1,0 +1,9 @@
+package org.terning.terningserver.external.user.respository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terning.terningserver.external.user.domain.UserSyncEvent;
+
+public interface UserSyncEventRepository extends JpaRepository<UserSyncEvent, Long> {
+    List<UserSyncEvent> findByProcessedFalse();
+}

--- a/src/main/java/org/terning/terningserver/external/user/scheduler/UserSyncScheduler.java
+++ b/src/main/java/org/terning/terningserver/external/user/scheduler/UserSyncScheduler.java
@@ -1,0 +1,46 @@
+package org.terning.terningserver.external.user.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserSyncScheduler {
+
+    private static final String JOB_PARAM_TIMESTAMP = "timestamp";
+
+    private final JobLauncher jobLauncher;
+    private final Job userSyncJob;
+
+    /**
+     * 매주 목, 토 오후 12:30에 실행 (푸시 알림 전송 30분 전)
+     */
+    @Scheduled(cron = "0 30 12 ? * THU,SAT", zone = "Asia/Seoul")
+    public void runUserSyncJobBeforeRecommendation() throws Exception {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong(JOB_PARAM_TIMESTAMP, System.currentTimeMillis())
+                .toJobParameters();
+        jobLauncher.run(userSyncJob, jobParameters);
+        log.info("User sync job for push status/name update (before recommendation) triggered at {}", LocalDateTime.now());
+    }
+
+    /**
+     * 매주 일요일 오후 8:30에 실행 (푸시 알림 전송 30분 전)
+     */
+    @Scheduled(cron = "0 30 20 ? * SUN", zone = "Asia/Seoul")
+    public void runUserSyncJobBeforeTrendingAlert() throws Exception {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong(JOB_PARAM_TIMESTAMP, System.currentTimeMillis())
+                .toJobParameters();
+        jobLauncher.run(userSyncJob, jobParameters);
+        log.info("User sync job for push status/name update (before trending alert) triggered at {}", LocalDateTime.now());
+    }
+}

--- a/src/main/java/org/terning/terningserver/service/UserService.java
+++ b/src/main/java/org/terning/terningserver/service/UserService.java
@@ -9,4 +9,5 @@ public interface UserService {
     ProfileResponseDto getProfile(Long userId);
 
     void updateProfile(Long userId, ProfileUpdateRequestDto request);
+    void updatePushStatus(Long userId, String newStatus);
 }


### PR DESCRIPTION
# 📄 Work Description
- 유저 상태(푸시알림 허용 여부, 유저 이름 변경, 회원 탈퇴) 시 알림서버 <> 운영서버 동기화를 구현했습니다.
- 사용자의 푸시알림 여부를 받아오기 위해, 운영서버의 user에도 pushStatus를 가지도록 추가했습니다.
- 푸시알림 상태변경은 마이페이지 > 유저 푸시알림 상태 변경 API를 추가해 변경하도록 하였습니다.
- 푸시알림 상태확인은 마이페이지 > 유저 프로필 정보 조회 API를 통해 한번에 조회하도록 하였습니다.
- 스케쥴링은 아래와 같이 설정했습니다.
  - 푸시 알림(추천 알림)이 오후 1시에 전송되기 30분 전에 사용자 정보 업데이트를 반영하기 위해서 매주 목요일과 토요일 오후 12시 30분에 동기화가 진행되도록 하였습니다.
  - 일요일 오후 9시에 전송되는 트렌딩 알림 전에 업데이트가 반영되도록 하기 위해서 매주 일요일 오후 8시 30분에 동기화가 진행되도록 설정했습니다.

# ⚙️ ISSUE
- closed #220 

