### PR TITLE
[🔨 fix] 스크랩 취소시, 스크랩 수에 대한 동시성 이슈를 해결하기 위해 비관적 락 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ Temporary Items
 # application.yml
 src/main/resources/application.yml
 src/main/resources/application-dev.yml
+src/test/resources/application-test.yml
 
 # Q-Class
 src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	// 테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 
 	// PostgreSQL
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'

--- a/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepository.java
+++ b/src/main/java/org/terning/terningserver/repository/internship_announcement/InternshipRepository.java
@@ -1,9 +1,16 @@
 package org.terning.terningserver.repository.internship_announcement;
 
+import jakarta.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.terning.terningserver.domain.InternshipAnnouncement;
+
+import java.util.Optional;
 
 public interface InternshipRepository extends JpaRepository<InternshipAnnouncement, Long>, InternshipRepositoryCustom {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<InternshipAnnouncement> findById(Long aLong);
 }
 

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -132,7 +132,7 @@ public class ScrapServiceImpl implements ScrapService {
 
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
 
-        announcement.updateScrapCount(1);
+        updateScrapCount(announcement, 1);
 
         scrapRepository.save(Scrap.create(
                 findUser(userId),
@@ -145,7 +145,8 @@ public class ScrapServiceImpl implements ScrapService {
     @Transactional
     public void deleteScrap(Long internshipAnnouncementId, Long userId) {
         Scrap scrap = findScrap(internshipAnnouncementId, userId);
-        scrap.getInternshipAnnouncement().updateScrapCount(-1);
+        InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
+        updateScrapCount(announcement, -1);
         verifyScrapOwner(scrap, userId);
         scrapRepository.deleteByInternshipAnnouncementIdAndUserId(internshipAnnouncementId, userId);
     }
@@ -158,7 +159,10 @@ public class ScrapServiceImpl implements ScrapService {
         scrap.updateColor(Color.findByName(request.color()));
     }
 
-    //토큰으로 찾은(요청한) User와 스크랩한 User가 일치한지 여부 검증하는 메서드
+    private void updateScrapCount(InternshipAnnouncement announcement, int plusOrMinus) {
+        announcement.updateScrapCount(plusOrMinus);
+    }
+
     private void verifyScrapOwner(Scrap scrap, Long userId) {
         if(!scrap.getUser().equals(findUser(userId))) {
             throw new CustomException(FORBIDDEN_DELETE_SCRAP);

--- a/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
+++ b/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
@@ -1,0 +1,117 @@
+package org.terning.terningserver.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import org.terning.terningserver.domain.Company;
+import org.terning.terningserver.domain.InternshipAnnouncement;
+import org.terning.terningserver.domain.Scrap;
+import org.terning.terningserver.domain.User;
+import org.terning.terningserver.domain.enums.AuthType;
+import org.terning.terningserver.domain.enums.Color;
+import org.terning.terningserver.domain.enums.CompanyCategory;
+import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
+import org.terning.terningserver.repository.scrap.ScrapRepository;
+import org.terning.terningserver.repository.user.UserRepository;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ScrapServiceTest {
+
+    @Autowired
+    private ScrapService scrapService;
+
+    @Autowired
+    private ScrapRepository scrapRepository;
+
+    @Autowired
+    private InternshipRepository internshipRepository;
+
+    @Autowired
+
+    private UserRepository userRepository;
+
+    @BeforeEach
+    public void before() {
+        Company company = new Company("info", CompanyCategory.OTHERS, "image");
+
+        InternshipAnnouncement announcement = new InternshipAnnouncement(
+                1L,
+                "test 공고",
+                LocalDate.now().plusDays(7),
+                "3개월",
+                2025,
+                4,
+                0,
+                100,
+                "https://mock.com",
+                null,
+                company,
+                "자격요건",
+                "직무 유형",
+                "상세 내용",
+                false
+        );
+
+        internshipRepository.save(announcement);
+
+        for (int i = 0; i < 100; i++) {
+            User user = User.builder()
+                    .authId("user" + i)
+                    .name("test" + i)
+                    .authType(AuthType.APPLE)
+                    .build();
+            userRepository.save(user);
+
+            Scrap scrap = Scrap.create(user, announcement, Color.BLUE);
+            scrapRepository.save(scrap);
+        }
+    }
+
+    @AfterEach
+    public void after() {
+        scrapRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        internshipRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("동시에 여러 유저가 스크랩 취소 시도 시 scrapCount 감소가 정상적으로 처리된다.")
+    public void requests_100_AtTheSameTime() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            long userId = userRepository.findByAuthId("user" + i).orElseThrow().getId();
+            executorService.submit(() -> {
+                try {
+                    scrapService.deleteScrap(1L, userId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        InternshipAnnouncement savedAnnouncement = internshipRepository.findById(1L).orElseThrow();
+        assertThat(savedAnnouncement.getScrapCount()).isEqualTo(0L);
+    }
+
+}


### PR DESCRIPTION
# 📄 Work Description
- 스크랩 취소시, InternshipAnnouncement 테이블의 scrapCount에 대한 Race Condition(경쟁 상태)가 발생하여 데이터 정합성을 보장하기 위해 비관적 락을 적용했습니다.

# ⚙️ ISSUE
- closed #222 


# 📷 Screenshot
 ## ⚡️ 문제 상황
- 우선 스크랩 수에 대한 동시성 문제가 있을 줄 몰랐어요.. 리팩을 위해 코드를 보다가 스크랩 수가 부정확하다는 사실을 발견했습니다..
- 아래 사진을 보시면 현재 스크랩 추가/취소 시에 `InternshipAnnouncement` 테이블에서 가지고 있는 `scrapCount`를 증감해주고 있는데요! 스크랩 취소 및 추가 시에 동시성 문제가 발생하여 스크랩 수를 업데이트하는 과정에서 문제가 발생한 것 같아요. 사진을 보시면 공고에 대한 스크랩 데이터는 실제 3개가 존재하는데 `scrapCount`는 4가 저장되어 있었어요.
![image](https://github.com/user-attachments/assets/9b432677-5e29-44ca-b816-95f48bdf67bd)

<br/>

 ## 🧪 동시성 테스트를 위한 테스트 코드 작성
- 실제 `scrapCount`에 대한 `Race Condition`(경쟁 상태)가 발생했는지 파악하기 위해, 테스트 코드를 작성하여 테스트를 해봤습니다.
- 테스트 환경
   - DB: h2 인메모리 모드 -> 빠르게 실행하고자 인메모리 모드로 진행했어요.
   - 시나리오: 멀티 스레드 환경, 동시에 100개의 API 요청이 왔다고 가정하고, `scrapCount`를 100개로 세팅을 해두고 모두 요청을 처리한 뒤 scrapCount가 0이 되는지 테스트 해보았습니다!

결과는 아래와 같이,, 테스트에 실패했어요. 0을 기대했지만, 결과는 스크랩 수가 71이었고, 스크랩 수라는 자원에 대한 경쟁 상태가 발생했다는 걸 알 수 있었습니다,,
<img src="https://github.com/user-attachments/assets/41029a94-971d-46cd-8e24-9c071cf6a0ca" width="280" height="200">

<br/>


 ## 🔓 동시성 문제 해결을 위한 비관적 락 적용
- `DB Lock` 적용할 때 `Lock`을 잡을 데이터를 명확히 식별하고, 갱신하는 데이터에 대해서만 `Lock`을 걸어야 데드락과 성능저하를 피할 수 있다고 하더라구요. 따라서 스크랩수를 가진 인턴 공고 데이터에 대해서만 Lock이 걸리게 했습니다.
```java
public interface InternshipRepository extends JpaRepository<InternshipAnnouncement, Long>, InternshipRepositoryCustom {

    @Lock(LockModeType.PESSIMISTIC_WRITE)
    Optional<InternshipAnnouncement> findById(Long announcementId);
}
```
![image](https://github.com/user-attachments/assets/77a1594a-8fe7-4e1f-8c18-7c5463a5e82f)


- 많은 동시성 제어 방법 중 비관적 락을 선택한 이유?
  - 위에서 제가 DB 캡쳐한 사진은 예시로 인턴공고가 70번일 때만 가져온 건데, 확인해봤을 때 꽤나 많은 공고가 10개 중에 4개 꼴?로 스크랩수가 부정확하게 저장되어있었어요.
  - 그래서 해당 상황처럼 여러 트랜잭션이 동시에 동일 데이터를 수정하려는 상황이 빈번하게 발생할 때는 낙관적 락 방식보다 비관적 락 방식이 적합하다고 판단했습니다!



# 💬 To Reviewers
1) 사실 저희 서비스에서 사용자가 동시에 스크랩 취소/추가를 하는 경우가 빈번하게 발생할 거라고 생각하지 못했어요,,, 그래서 스크랩수가 불일치하는 문제가 100% 동시성 문제! 라고 확실하게 말하지는 못할 것 같아요.. 원인을 더 찾아보긴 해야겠지만, 테스트 코드로 테스트 해봤을 때는 동시성 문제가 충분히 발생할 수 있는 상황인 것은 분명히 맞기에 비관적 락을 적용했습니다!

다른 문제라고 생각이 드신다면 편하게 알려주시면 감사하겠습니다 ,,,ㅎㅎㅎ 

2) 위에서 잠깐 언급했듯이, 꽤나 많은 공고의 스크랩수가 부정확하게 저장되고 있어요...! 그래서 한 번 Prod 서버의 스크랩수를 update해줘야 할 것 같은데 .. 요거 저희 푸시알림 정식 업데이트 할 때 서비스 아마 이용 못하게 점검 시간? 있다고 하면 이때 후딱 작업하는게 어떨지 지금 드는 생각은 그런데, 다들 어떻게 생각하시는지 !?!?


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
