### PR TITLE
[🔨 fix] Docker 컨테이너 로그로도 로그 확인할 수 있도록 HTTP 요청/응답 로깅 설정 수정

### DIFF
--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -23,11 +23,12 @@
     <appender name="TERNING_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
+            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern> <!-- 매일 새로운 파일 생성 -->
+            <maxHistory>14</maxHistory> <!-- 14일간 보관 -->
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [%X{traceId:-NoTraceID}] - %msg%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -1,20 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <springProperty name="LOG_HOME_PATH" source="logging.location"/>
     <property name="LOG_PATH" value="${LOG_HOME_PATH}/dev-logs"/>
     <property name="LOG_FILE" value="${LOG_PATH}/terning.log"/>
+
+    <!-- stdout (정상 로그용) -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- stderr (에러 로그용) -->
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 로그 -->
     <appender name="TERNING_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern> <!-- 매일 새로운 파일 생성 -->
-            <maxHistory>14</maxHistory> <!-- 14일간 보관 -->
+            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [%X{traceId:-NoTraceID}] - %msg%n
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+
     <logger name="org.terning.terningserver" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
         <appender-ref ref="TERNING_LOG"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="TERNING_LOG"/>
+    </root>
+
+    <logger name="ERROR_LOGGER" level="WARN" additivity="false">
+        <appender-ref ref="STDERR"/>
     </logger>
 </configuration>

--- a/src/main/resources/logback-prod.xml
+++ b/src/main/resources/logback-prod.xml
@@ -23,11 +23,12 @@
     <appender name="TERNING_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
+            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern> <!-- 매일 새로운 파일 생성 -->
+            <maxHistory>14</maxHistory> <!-- 14일간 보관 -->
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [%X{traceId:-NoTraceID}] - %msg%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-prod.xml
+++ b/src/main/resources/logback-prod.xml
@@ -1,20 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <springProperty name="LOG_HOME_PATH" source="logging.location"/>
     <property name="LOG_PATH" value="${LOG_HOME_PATH}/prod-logs"/>
     <property name="LOG_FILE" value="${LOG_PATH}/terning.log"/>
+
+    <!-- stdout (정상 로그용) -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- stderr (에러 로그용) -->
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 로그 -->
     <appender name="TERNING_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern> <!-- 매일 새로운 파일 생성 -->
-            <maxHistory>30</maxHistory> <!-- 30일간 보관 -->
+            <fileNamePattern>${LOG_PATH}/terning-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} [%X{traceId:-NoTraceID}] - %msg%n
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+
     <logger name="org.terning.terningserver" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
         <appender-ref ref="TERNING_LOG"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="TERNING_LOG"/>
+    </root>
+
+    <logger name="ERROR_LOGGER" level="WARN" additivity="false">
+        <appender-ref ref="STDERR"/>
     </logger>
 </configuration>


### PR DESCRIPTION
# 📄 Work Description
- Docker 컨테이너 로그로도 로그 확인할 수 있도록 logback 설정을 수정했습니다!

# ⚙️ ISSUE
- closed #227 


# 💬 To Reviewers
## ⚡️문제 상황

> docker logs -f 했는데 실행 로그가 안 보여요..!

- HTTP 요청/응답 로깅을 스테이징 및 운영환경에서는 파일로 로그가 기록되도록 RollingFileAppender만 사용중인 상황이었습니다.
- 이로 인해 **Docker 환경에서 docker logs로 로그가 보이지 않는 문제 발생가 발생했어요.**
  - 최근 Docker 컨테이너가 잠깐 올라갔다가 에러로 인해 바로 내려가는 상황이 발생해서 `docker logs -f <컨테이너 id>`로 로그를 확인하려 했더니, SQL 쿼리만 찍히고 아무것도 찍히지 않아서 문제를 파악하기 어려웠습니다.. 

<br/>


## 🔆 해결 과정

우선 제가 설정한 HTTP 요청/응답 로깅과 컨테이너 실행 로그와 어떤 관련이 있는지부터 알아보았는데요!
Docker는 `stdout/stderr` 스트림을 기반으로 로그를 수집한다고 합니다. 하지만 기존의 logback 설정에서는 `RollingFileAppender`만 사용하고 있어, 로그가 파일로만 저장되고 stdout에는 출력되지 않았습니다.
 

> ⚠️ 결론: 도커는 `stdout/stderr` 스트림을 기반으로 로그를 수집하는데, `logging driver` 가 로그를 파일, 호스트 또는 DB 등에 저장하게 되면 docker logs 명령어로는 로그를 확인할 수 없게 됨.



- 이에 따라 logback 설정에 ConsoleAppender를 추가하고, HTTP 요청/응답을 포함한 주요 로그가 stdout에도 함께 출력되도록 구성했습니다.
- HTTP 요청/응답 로그는 파일로 따로 저장되며, 동시에 docker logs 명령어로도 실시간 확인가능하도록 수정했습니다!


<br/>

우선 스테이징 환경부터 배포해서, 원하는 대로 로그를 확인할 수 있는지 살펴봐야할 것 같아요! 

# 🔗 Reference
[[Docker] Container Logging 에 대해 알아보자.]( https://sonseungha.tistory.com/618)      