### PR TITLE
[🔨 fix] 스크랩 추가시, 스크랩 수에 대한 동시성 테스트 진행

### DIFF
--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -130,13 +130,11 @@ public class ScrapServiceImpl implements ScrapService {
         }
 
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
-
         scrapRepository.save(Scrap.create(
                 findUser(userId),
                 announcement,
                 findColor(request.color())
         ));
-
         updateScrapCount(announcement, 1);
     }
 

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -125,13 +125,11 @@ public class ScrapServiceImpl implements ScrapService {
     @Transactional
     public void createScrap(Long internshipAnnouncementId, CreateScrapRequestDto request, Long userId) {
 
-        //이미 스크랩 했을 경우 예외처리
         if(scrapRepository.existsByInternshipAnnouncementIdAndUserId(internshipAnnouncementId, userId)) {
             throw new CustomException(EXISTS_SCRAP_ALREADY);
         }
 
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
-
         updateScrapCount(announcement, 1);
 
         scrapRepository.save(Scrap.create(
@@ -146,8 +144,8 @@ public class ScrapServiceImpl implements ScrapService {
     public void deleteScrap(Long internshipAnnouncementId, Long userId) {
         Scrap scrap = findScrap(internshipAnnouncementId, userId);
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
-        updateScrapCount(announcement, -1);
         verifyScrapOwner(scrap, userId);
+        updateScrapCount(announcement, -1);
         scrapRepository.deleteByInternshipAnnouncementIdAndUserId(internshipAnnouncementId, userId);
     }
 

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -144,8 +144,8 @@ public class ScrapServiceImpl implements ScrapService {
         Scrap scrap = findScrap(internshipAnnouncementId, userId);
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
         verifyScrapOwner(scrap, userId);
-        updateScrapCount(announcement, -1);
         scrapRepository.deleteByInternshipAnnouncementIdAndUserId(internshipAnnouncementId, userId);
+        updateScrapCount(announcement, -1);
     }
 
     @Override

--- a/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/service/ScrapServiceImpl.java
@@ -130,13 +130,14 @@ public class ScrapServiceImpl implements ScrapService {
         }
 
         InternshipAnnouncement announcement = getInternshipAnnouncement(internshipAnnouncementId);
-        updateScrapCount(announcement, 1);
 
         scrapRepository.save(Scrap.create(
                 findUser(userId),
-                getInternshipAnnouncement(internshipAnnouncementId),
+                announcement,
                 findColor(request.color())
         ));
+
+        updateScrapCount(announcement, 1);
     }
 
     @Override

--- a/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
+++ b/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
@@ -207,6 +207,7 @@ class ScrapServiceTest {
             });
 
             InternshipAnnouncement savedAnnouncement = internshipRepository.findById(internshipAnnouncementId).orElseThrow();
+            assertThat(exception.getMessage()).isEqualTo("스크랩 정보가 존재하지 않습니다");
             assertThat(savedAnnouncement.getScrapCount()).isEqualTo(100L);
         }
     }

--- a/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
+++ b/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
@@ -18,6 +18,7 @@ import org.terning.terningserver.domain.enums.AuthType;
 import org.terning.terningserver.domain.enums.Color;
 import org.terning.terningserver.domain.enums.CompanyCategory;
 import org.terning.terningserver.dto.scrap.request.CreateScrapRequestDto;
+import org.terning.terningserver.exception.CustomException;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
@@ -28,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @SpringBootTest
@@ -192,6 +194,20 @@ class ScrapServiceTest {
             InternshipAnnouncement savedAnnouncement = internshipRepository.findById(1L).orElseThrow();
             assertThat(savedAnnouncement.getScrapCount()).isEqualTo(0L);
             assertThat(scrapRepository.count()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("스크랩 취소시에 Unchecked Exception 발생 시 트랜잭션 롤백이 정상적으로 처리된다.")
+        public void 트랜잭션_롤백_테스트() {
+            Long userId = 10000L;
+            Long internshipAnnouncementId = 1L;
+
+            RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+                scrapService.deleteScrap(internshipAnnouncementId, userId);
+            });
+
+            InternshipAnnouncement savedAnnouncement = internshipRepository.findById(internshipAnnouncementId).orElseThrow();
+            assertThat(savedAnnouncement.getScrapCount()).isEqualTo(100L);
         }
     }
 }

--- a/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
+++ b/src/test/java/org/terning/terningserver/service/ScrapServiceTest.java
@@ -3,6 +3,7 @@ package org.terning.terningserver.service;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,7 @@ import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.AuthType;
 import org.terning.terningserver.domain.enums.Color;
 import org.terning.terningserver.domain.enums.CompanyCategory;
+import org.terning.terningserver.dto.scrap.request.CreateScrapRequestDto;
 import org.terning.terningserver.repository.internship_announcement.InternshipRepository;
 import org.terning.terningserver.repository.scrap.ScrapRepository;
 import org.terning.terningserver.repository.user.UserRepository;
@@ -32,86 +34,164 @@ import static org.assertj.core.api.Assertions.*;
 @ActiveProfiles("test")
 class ScrapServiceTest {
 
-    @Autowired
-    private ScrapService scrapService;
-
-    @Autowired
-    private ScrapRepository scrapRepository;
-
-    @Autowired
-    private InternshipRepository internshipRepository;
-
-    @Autowired
-
-    private UserRepository userRepository;
-
-    @BeforeEach
-    public void before() {
-        Company company = new Company("info", CompanyCategory.OTHERS, "image");
-
-        InternshipAnnouncement announcement = new InternshipAnnouncement(
-                1L,
-                "test 공고",
-                LocalDate.now().plusDays(7),
-                "3개월",
-                2025,
-                4,
-                0,
-                100,
-                "https://mock.com",
-                null,
-                company,
-                "자격요건",
-                "직무 유형",
-                "상세 내용",
-                false
-        );
-
-        internshipRepository.save(announcement);
-
-        for (int i = 0; i < 100; i++) {
-            User user = User.builder()
-                    .authId("user" + i)
-                    .name("test" + i)
-                    .authType(AuthType.APPLE)
-                    .build();
-            userRepository.save(user);
-
-            Scrap scrap = Scrap.create(user, announcement, Color.BLUE);
-            scrapRepository.save(scrap);
-        }
-    }
+    @Autowired private ScrapService scrapService;
+    @Autowired private ScrapRepository scrapRepository;
+    @Autowired private InternshipRepository internshipRepository;
+    @Autowired private UserRepository userRepository;
 
     @AfterEach
-    public void after() {
+    public void cleanUp() {
         scrapRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         internshipRepository.deleteAllInBatch();
     }
 
-    @Test
-    @DisplayName("동시에 여러 유저가 스크랩 취소 시도 시 scrapCount 감소가 정상적으로 처리된다.")
-    public void requests_100_AtTheSameTime() throws InterruptedException {
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(32);
+    @Nested
+    @DisplayName("스크랩 추가 테스트")
+    class CreateScrapTest {
 
-        CountDownLatch latch = new CountDownLatch(threadCount);
+        @BeforeEach
+        public void setup() {
+            Company company = new Company("info", CompanyCategory.OTHERS, "image");
 
-        for (int i = 0; i < threadCount; i++) {
-            long userId = userRepository.findByAuthId("user" + i).orElseThrow().getId();
-            executorService.submit(() -> {
-                try {
-                    scrapService.deleteScrap(1L, userId);
-                } finally {
-                    latch.countDown();
-                }
-            });
+            InternshipAnnouncement announcement = new InternshipAnnouncement(
+                    1L,
+                    "test 공고",
+                    LocalDate.now().plusDays(7),
+                    "3개월",
+                    2025,
+                    4,
+                    0,
+                    5,
+                    "https://mock.com",
+                    null,
+                    company,
+                    "자격요건",
+                    "직무 유형",
+                    "상세 내용",
+                    false
+            );
+
+            internshipRepository.save(announcement);
+
+            for (int i = 0; i < 5; i++) {
+                User user = User.builder()
+                        .authId("user" + i)
+                        .name("test" + i)
+                        .authType(AuthType.APPLE)
+                        .build();
+                userRepository.save(user);
+
+                Scrap scrap = Scrap.create(user, announcement, Color.BLUE);
+                scrapRepository.save(scrap);
+            }
+
+            for (int i = 5; i < 105; i++) {
+                User user = User.builder()
+                        .authId("user" + i)
+                        .name("test" + i)
+                        .authType(AuthType.APPLE)
+                        .build();
+                userRepository.save(user);
+            }
         }
 
-        latch.await();
+        @Test
+        @DisplayName("동시에 여러 유저가 스크랩 추가 시 scrapCount 증가가 정상적으로 처리된다.")
+        public void 동시에_여러_유저가_스크랩_추가() throws InterruptedException {
+            int threadCount = 100;
+            ExecutorService executorService = Executors.newFixedThreadPool(32);
+            CountDownLatch latch = new CountDownLatch(threadCount);
 
-        InternshipAnnouncement savedAnnouncement = internshipRepository.findById(1L).orElseThrow();
-        assertThat(savedAnnouncement.getScrapCount()).isEqualTo(0L);
+            CreateScrapRequestDto requestDto = new CreateScrapRequestDto("red");
+
+            for (int i = 5; i < 105; i++) {
+                long userId = userRepository.findByAuthId("user" + i).orElseThrow().getId();
+                executorService.submit(() -> {
+                    try {
+                        scrapService.createScrap(1L, requestDto, userId);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            executorService.shutdown();
+
+
+            InternshipAnnouncement savedAnnouncement = internshipRepository.findById(1L).orElseThrow();
+            assertThat(savedAnnouncement.getScrapCount()).isEqualTo(105L);
+            assertThat(scrapRepository.count()).isEqualTo(105L);
+
+        }
     }
 
+    @Nested
+    @DisplayName("스크랩 취소 테스트")
+    class DeleteScrapTest {
+
+        @BeforeEach
+        public void setup() {
+            Company company = new Company("info", CompanyCategory.OTHERS, "image");
+
+            InternshipAnnouncement announcement = new InternshipAnnouncement(
+                    1L,
+                    "test 공고",
+                    LocalDate.now().plusDays(7),
+                    "3개월",
+                    2025,
+                    4,
+                    0,
+                    100, // scrapCount = 100
+                    "https://mock.com",
+                    null,
+                    company,
+                    "자격요건",
+                    "직무 유형",
+                    "상세 내용",
+                    false
+            );
+
+            internshipRepository.save(announcement);
+
+            for (int i = 0; i < 100; i++) {
+                User user = User.builder()
+                        .authId("user" + i)
+                        .name("test" + i)
+                        .authType(AuthType.APPLE)
+                        .build();
+                userRepository.save(user);
+
+                Scrap scrap = Scrap.create(user, announcement, Color.BLUE);
+                scrapRepository.save(scrap);
+            }
+        }
+
+        @Test
+        @DisplayName("동시에 여러 유저가 스크랩 취소 시 scrapCount 감소가 정상적으로 처리된다.")
+        public void 동시에_여러_유저가_스크랩_취소() throws InterruptedException {
+            int threadCount = 100;
+            ExecutorService executorService = Executors.newFixedThreadPool(32);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < 100; i++) {
+                long userId = userRepository.findByAuthId("user" + i).orElseThrow().getId();
+                executorService.submit(() -> {
+                    try {
+                        scrapService.deleteScrap(1L, userId);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            executorService.shutdown();
+
+            InternshipAnnouncement savedAnnouncement = internshipRepository.findById(1L).orElseThrow();
+            assertThat(savedAnnouncement.getScrapCount()).isEqualTo(0L);
+            assertThat(scrapRepository.count()).isEqualTo(0L);
+        }
+    }
 }


### PR DESCRIPTION
# 📄 Work Description
- 스크랩 추가시, 스크랩 추가시, 스크랩 수에 대한 동시성 테스트를 진행했습니다 (테스트 코드 작성)
- 이전 PR과 이어지는 내용이에요! 참고 부탁드려요:)
  - https://github.com/teamterning/Terning-Server/pull/225


# ⚙️ ISSUE
- closed #234 


# 📷 Screenshot
<img width="556" alt="image" src="https://github.com/user-attachments/assets/52d3d1ed-10ee-44b1-8e64-408ddb448d99" />



# 💬 To Reviewers
- 스크랩 추가시 여러 요청이 올 때 스크랩 수와 실제 스크랩 수 테이블의 데이터 개수가 일치하는 지에 대한 동시성 테스트를 진행했어요:)
  - 비관적 락 적용은 이전 PR에서 공고 조회시 걸도록 해놓았기 때문에, 해당 PR에서는 테스트 코드를 작성하여 정상적으로 동작하는지 검증했습니다! 

> Scrap 저장 및 scrapCount 업데이트 기능을 실제 DB 연동 및 트랜잭션 처리까지 검증하기 위해 통합테스트(SpringBootTest)로 작성했습니다.

- 아직도 의문이 드는건,,, 저번 PR에 적긴했지만 스크랩수가 불일치하는 문제가 동시성 문제가 맞는지 확신하지 못하겠는 부분이 조금 걸리는 것 같아요..!  
  -  현재 스크랩 수 update 후 스크랩 데이터 저장을 하고 있는데, 한 트랜잭션 안에서 일어나다 보니 스크랩 저장 과정에서 에러가 발생해도 롤백이 되어 스크랩 수가 update되지 않을 것이라서,,


# 🔗 Reference
https://persi0815.tistory.com/29