### PR TITLE
[feat] 소셜로그인 시, 알림서버와 운영서버의 유저를 동기화 하는 로직 추가

### DIFF
--- a/src/main/java/org/terning/terningserver/auth/application/signin/AuthSignInServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/auth/application/signin/AuthSignInServiceImpl.java
@@ -41,7 +41,7 @@ public class AuthSignInServiceImpl implements AuthSignInService {
 //        boolean fcmReissueRequired = fcmTokenValidationClient.requestFcmTokenValidation(user.getId());
 
         if (request.fcmToken() != null && !request.fcmToken().trim().isEmpty()) {
-            notificationUserClient.updateFcmToken(user.getId(), request.fcmToken());
+            notificationUserClient.createOrUpdateUser(user, request.fcmToken());
         }
 
 //        return SignInResponse.of(token, authId, request.authType(), user.getId(), fcmReissueRequired);

--- a/src/main/java/org/terning/terningserver/external/notification/NotificationUserClient.java
+++ b/src/main/java/org/terning/terningserver/external/notification/NotificationUserClient.java
@@ -2,6 +2,9 @@ package org.terning.terningserver.external.notification;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.terning.terningserver.domain.User;
 import org.terning.terningserver.domain.enums.AuthType;
 import org.terning.terningserver.external.dto.request.CreateUserRequest;
 import org.springframework.stereotype.Component;
@@ -48,6 +51,28 @@ public class NotificationUserClient {
                 .block();
 
         log.info("User (id={}) created on notification server : ", userId);
+    }
+
+    /**
+     * 소셜로그인 시 알림서버와 운영서버간 유저 동기화를 진행합니다.
+     * @param user      유저 객체
+     * @param fcmToken  fcm 토큰
+     */
+    public void createOrUpdateUser(User user, String fcmToken) {
+        try {
+            updateFcmToken(user.getId(), fcmToken);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                createUserOnNotificationServer(
+                        user.getId(),
+                        user.getName(),
+                        user.getAuthType(),
+                        fcmToken
+                );
+            } else {
+                throw e;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
# 📄 Work Description
- 기존에는 회원가입 시에만 알림서버 DB에 유저를 새롭게 추가하는 방식으로 구현되어있었습니다.
- 하지만, 운영서버가 메인으로 설정되게 되면, 기존 유저의 경우 fcm토큰을 가지고 있지 않고, 알림서버 연결이 안되어있는 상황이였기 때문에, 알림서버에 유저를 소셜로그인 할때도 동기화를 해주어야 합니다.
- 따라서 소셜로그인 시, 알림서버와 운영서버의 유저를 동기화 하는 로직을 추가했습니다.
 - 소셜로그인 시, 기존의 알림서버에 토큰 업데이트 요청을 하고, 만약, 유저정보가 존재하지 않는 경우, 알림서버에 해당 유저의 정보를 추가하도록 로직을 구현했습니다.

# ⚙️ ISSUE
- closed #238 


# 📷 Screenshot
### 운영서버에는 존재하지만, 알림서버에 현재 `테스트`이라는 이름의 유저가 반영이 안되어있는 상황

**<운영서버>**
<img width="459" alt="image" src="https://github.com/user-attachments/assets/9d4db09b-56dd-4189-88d7-75b5e72bf1dc" />

**<알림서버>**
<img width="450" alt="image" src="https://github.com/user-attachments/assets/cba680d0-36a6-4751-b2ee-9f175480f154" />

### 소셜로그인 성공
<img width="789" alt="image" src="https://github.com/user-attachments/assets/2cd124be-f107-466f-a6cf-ed8e2d7bbc9d" />

### 소셜로그인 진행한 이후 알림서버 DB에 새롭게 반영된 상황
<img width="465" alt="image" src="https://github.com/user-attachments/assets/20984876-a2e2-4e62-8fe1-6e2e28c9f397" />

