### PR TITLE
[✨ feat] 일회성 유저 동기화 API 구현

### DIFF
--- a/src/main/java/org/terning/terningserver/auth/api/AuthController.java
+++ b/src/main/java/org/terning/terningserver/auth/api/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.terning.terningserver.auth.application.AuthService;
+import org.terning.terningserver.auth.dto.request.FcmTokenSyncRequest;
 import org.terning.terningserver.auth.dto.request.SignInRequest;
 import org.terning.terningserver.auth.dto.request.SignUpFilterRequestDto;
 import org.terning.terningserver.auth.dto.request.SignUpRequestDto;
@@ -19,6 +20,7 @@ import static org.terning.terningserver.common.exception.enums.SuccessMessage.SU
 import static org.terning.terningserver.common.exception.enums.SuccessMessage.SUCCESS_SIGN_OUT;
 import static org.terning.terningserver.common.exception.enums.SuccessMessage.SUCCESS_SIGN_UP;
 import static org.terning.terningserver.common.exception.enums.SuccessMessage.SUCCESS_SIGN_UP_FILTER;
+import static org.terning.terningserver.common.exception.enums.SuccessMessage.SUCCESS_USER_SYNC;
 import static org.terning.terningserver.common.exception.enums.SuccessMessage.SUCCESS_WITHDRAW;
 
 
@@ -77,5 +79,14 @@ public class AuthController implements AuthSwagger {
         authService.withdraw(userId);
 
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_WITHDRAW));
+    }
+
+    @PostMapping("/sync-user")
+    public ResponseEntity<SuccessResponse> syncUser(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody FcmTokenSyncRequest request
+    ) {
+        authService.syncUser(userId, request);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_USER_SYNC));
     }
 }

--- a/src/main/java/org/terning/terningserver/auth/api/AuthSwagger.java
+++ b/src/main/java/org/terning/terningserver/auth/api/AuthSwagger.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.terning.terningserver.auth.dto.request.FcmTokenSyncRequest;
 import org.terning.terningserver.auth.dto.request.SignInRequest;
 import org.terning.terningserver.auth.dto.request.SignUpFilterRequestDto;
 import org.terning.terningserver.auth.dto.request.SignUpRequestDto;
@@ -52,4 +53,10 @@ public interface AuthSwagger {
     @Operation(summary = "계정탈퇴", description = "계정탈퇴 API")
     ResponseEntity<SuccessResponse> withdraw(
             @AuthenticationPrincipal Long userId);
+
+    @Operation(summary = "유저동기화", description = "유저동기화 API")
+    ResponseEntity<SuccessResponse> syncUser(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody FcmTokenSyncRequest request
+    );
 }

--- a/src/main/java/org/terning/terningserver/auth/application/AuthService.java
+++ b/src/main/java/org/terning/terningserver/auth/application/AuthService.java
@@ -7,7 +7,9 @@ import org.terning.terningserver.auth.application.reissue.AuthReissueService;
 import org.terning.terningserver.auth.application.signin.AuthSignInService;
 import org.terning.terningserver.auth.application.signout.AuthSignOutService;
 import org.terning.terningserver.auth.application.signup.AuthSignUpService;
+import org.terning.terningserver.auth.application.syncUser.AuthSyncUserService;
 import org.terning.terningserver.auth.application.withdraw.AuthWithdrawService;
+import org.terning.terningserver.auth.dto.request.FcmTokenSyncRequest;
 import org.terning.terningserver.auth.dto.request.SignInRequest;
 import org.terning.terningserver.auth.dto.request.SignUpFilterRequestDto;
 import org.terning.terningserver.auth.dto.request.SignUpRequestDto;
@@ -25,6 +27,7 @@ public class AuthService {
     private final AuthSignOutService authSignOutService;
     private final AuthWithdrawService authWithdrawService;
     private final AuthReissueService authReissueService;
+    private final AuthSyncUserService authSyncUserService;
 
     @Transactional
     public SignInResponse signIn(String authAccessToken, SignInRequest request) {
@@ -57,5 +60,10 @@ public class AuthService {
     public AccessTokenGetResponseDto reissueToken(String refreshToken) {
         AccessTokenGetResponseDto accessTokenGetResponseDto = authReissueService.reissueToken(refreshToken);
         return accessTokenGetResponseDto;
+    }
+
+    @Transactional
+    public void syncUser(long userId, FcmTokenSyncRequest request) {
+        authSyncUserService.syncUser(userId, request);
     }
 }

--- a/src/main/java/org/terning/terningserver/auth/application/syncUser/AuthSyncUserService.java
+++ b/src/main/java/org/terning/terningserver/auth/application/syncUser/AuthSyncUserService.java
@@ -1,0 +1,8 @@
+package org.terning.terningserver.auth.application.syncUser;
+
+import org.terning.terningserver.auth.dto.request.FcmTokenSyncRequest;
+
+public interface AuthSyncUserService {
+
+    void syncUser(long userId, FcmTokenSyncRequest request);
+}

--- a/src/main/java/org/terning/terningserver/auth/application/syncUser/AuthSyncUserServiceImpl.java
+++ b/src/main/java/org/terning/terningserver/auth/application/syncUser/AuthSyncUserServiceImpl.java
@@ -1,0 +1,29 @@
+package org.terning.terningserver.auth.application.syncUser;
+
+import static org.terning.terningserver.common.exception.enums.ErrorMessage.NOT_FOUND_USER_EXCEPTION;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.terning.terningserver.auth.dto.request.FcmTokenSyncRequest;
+import org.terning.terningserver.common.exception.CustomException;
+import org.terning.terningserver.external.pushNotification.notification.NotificationUserClient;
+import org.terning.terningserver.user.domain.User;
+import org.terning.terningserver.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthSyncUserServiceImpl implements AuthSyncUserService {
+
+    private final UserRepository userRepository;
+    private final NotificationUserClient notificationUserClient;
+
+    @Transactional
+    @Override
+    public void syncUser(long userId, FcmTokenSyncRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_USER_EXCEPTION));
+
+        notificationUserClient.createOrUpdateUser(user, request.fcmToken());
+    }
+}

--- a/src/main/java/org/terning/terningserver/auth/dto/request/FcmTokenSyncRequest.java
+++ b/src/main/java/org/terning/terningserver/auth/dto/request/FcmTokenSyncRequest.java
@@ -1,0 +1,6 @@
+package org.terning.terningserver.auth.dto.request;
+
+public record FcmTokenSyncRequest(
+        String fcmToken
+) {
+}

--- a/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.terning.terningserver.common.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.terning.terningserver.common.security.jwt.filter.JwtAuthenticationFil
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(pre)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
@@ -16,7 +16,7 @@ import org.terning.terningserver.common.security.jwt.filter.JwtAuthenticationFil
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableMethodSecurity(pre)
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/org/terning/terningserver/common/exception/enums/SuccessMessage.java
+++ b/src/main/java/org/terning/terningserver/common/exception/enums/SuccessMessage.java
@@ -55,8 +55,10 @@ public enum SuccessMessage {
     // My page (마이페이지 화면)
     SUCCESS_GET_PROFILE(200, "마이페이지 > 프로필 정보 불러오기를 성공했습니다"),
     SUCCESS_UPDATE_PROFILE(200, "프로필 수정에 성공했습니다"),
-    PUSH_STATUS_UPDATED(200, "사용자 푸시알림 여부 변경을 완료했습니다.");
+    PUSH_STATUS_UPDATED(200, "사용자 푸시알림 여부 변경을 완료했습니다."),
 
+    // 유저 동기화
+    SUCCESS_USER_SYNC(201, "유저 동기화를 성공했습니다.");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
# 📄 Work Description
- 기존 운영서버 유저가 소셜로그인을 다시 하지 않아도 알림서버에 FCM 토큰을 `동기화`할 수 있도록 하기 위한 API 구현했습니다.
- 로그인된 사용자가 홈 화면 진입 시, 유저 정보가 알림서버에 없으면 `새로 등록`하고, 있다면 FCM 토큰만 `갱신`하도록 했습니다.
- `실제 로그인한 유저`만 해당 API를 적용할 수 있도록 사전에 security에서 인증을 요구하도록 어노테이션을 추가했습니다.

# ⚙️ ISSUE
- closed #243 


# 📷 Screenshot
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/7c001633-b7f5-4074-8e6b-a038483758c1" />