### PR TITLE
[🔨 fix]  JWT 필터가 인증 예외 경로를 건너뛰도록 개선

### DIFF
--- a/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
@@ -21,7 +21,8 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
-    private static final String[] AUTH_WHITELIST = {
+
+    public static final String[] AUTH_WHITELIST = {
             "/v3/api-docs/**",
             "/swagger-ui.html",
             "/api/v1/swagger-ui/index.html#/**",
@@ -46,9 +47,9 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandling ->
                         exceptionHandling.authenticationEntryPoint(customJwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> {
-                            auth.requestMatchers(AUTH_WHITELIST).permitAll();
-                            auth.anyRequest().authenticated();
-                        })
+                    auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/org/terning/terningserver/common/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/terning/terningserver/common/security/jwt/filter/JwtAuthenticationFilter.java
@@ -11,7 +11,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.terning.terningserver.common.config.SecurityConfig;
 import org.terning.terningserver.common.security.jwt.application.JwtUserIdExtractor;
 import org.terning.terningserver.common.security.jwt.auth.UserAuthentication;
 import org.terning.terningserver.common.security.jwt.exception.JwtException;
@@ -30,6 +32,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUserIdExtractor jwtUserIdExtractor;
     private final RateLimitingService rateLimitingService;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        for (String pattern : SecurityConfig.AUTH_WHITELIST) {
+            if (antPathMatcher.match(pattern, requestURI)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)


### PR DESCRIPTION
# 📄 Work Description
### 문제 상황
기존 `JwtAuthenticationFilter`는 `SecurityConfig`의 `permitAll` 설정과 관계없이 모든 요청 헤더에 있는 토큰의 유효성을 검사했습니다. 이로 인해 토큰 재발급, 소셜 로그인 등 만료된 토큰을 사용하거나 토큰이 없는 상태로 접근해야 하는 인증 관련 API 요청이 필터 단계에서 미리 차단되는 문제가 발생했습니다.

### 해결 방안
`OncePerRequestFilter`가 제공하는 `shouldNotFilter` 메소드를 오버라이드하여, `SecurityConfig`에 정의된 `AUTH_WHITELIST` 경로에 대해서는 `JwtAuthenticationFilter`가 동작하지 않도록 수정했습니다.

이를 통해 인증이 필요 없는 경로는 토큰 유효성 검사를 안전하게 통과하여, 의도한 대로 컨트롤러에서 요청을 처리할 수 있도록 개선했습니다.

### 주요 변경 사항
- **JwtAuthenticationFilter**: `shouldNotFilter`를 구현하여 인증 예외 경로에 대한 필터링 로직을 제외했습니다.
- **SecurityConfig**: `AUTH_WHITELIST`의 접근 제어자를 `public`으로 변경하여 `JwtAuthenticationFilter`에서 참조할 수 있도록 수정했습니다.

