### PR TITLE
[FEAT] 모니터링 환경 구축 및 과부화 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
@@ -59,6 +58,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2'
+
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 // QueryDSL Settings

--- a/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/terning/terningserver/common/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
             "/api/v1/users/**",
             "/api/v1/push-status",
             "/api/v1/external/scraps/unsynced",
-            "/api/v1/external/scraps/sync/result"
+            "/api/v1/external/scraps/sync/result",
+            "/actuator/**",
     };
 
     @Bean

--- a/src/main/java/org/terning/terningserver/external/pushNotification/user/domain/UserSyncEvent.java
+++ b/src/main/java/org/terning/terningserver/external/pushNotification/user/domain/UserSyncEvent.java
@@ -1,6 +1,7 @@
 package org.terning.terningserver.external.pushNotification.user.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,7 +25,7 @@ public class UserSyncEvent {
 
     private Long userId;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private UserSyncEventType eventType;
 
     private String newValue;

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,36 +1,36 @@
-spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_UPPER=FALSE
-    username: sa
-    password:
-#    driver-class-name: org.h2.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-        format_sql: true
-    show-sql: true
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  batch:
-    job:
-      enabled: false
-
-jwt:
-  secret-key: "this-is-a-temporary-secret-key-for-local-tests-1234567890"
-  access-token-expired: 3600000
-  refresh-token-expired: 86400000
-
-operation:
-  base-url: http://localhost:9999
-
-discord:
-  webhook:
-    url: "https://discord.com/api/webhooks/test/test"
+#spring:
+#  datasource:
+#    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_UPPER=FALSE
+#    username: sa
+#    password:
+##    driver-class-name: org.h2.Driver
+#
+#  jpa:
+#    hibernate:
+#      ddl-auto: create-drop
+#    properties:
+#      hibernate:
+#        dialect: org.hibernate.dialect.H2Dialect
+#        format_sql: true
+#    show-sql: true
+#
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2-console
+#
+#  batch:
+#    job:
+#      enabled: false
+#
+#jwt:
+#  secret-key: "this-is-a-temporary-secret-key-for-local-tests-1234567890"
+#  access-token-expired: 3600000
+#  refresh-token-expired: 86400000
+#
+#operation:
+#  base-url: http://localhost:9999
+#
+#discord:
+#  webhook:
+#    url: "https://discord.com/api/webhooks/test/test"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,12 @@ discord:
 
 firebase:
   service-key: ${FIREBASE_SERVICE_KEY_JSON}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    prometheus:
+      enabled: true


### PR DESCRIPTION
# 📄 Work Description
- 서버의 상태 지표를 수집하고 시각화하기 위해 프로메테우스 및 그라파나 연동을 위한 기반 설정을 추가합니다. Spring Boot Actuator를 통해 메트릭을 노출하고, 프로메테우스가 이를 수집할 수 있도록 관련 의존성, 설정, 보안 규칙을 변경합니다.


# 💬 To Reviewers

모니터링 설정
- build.gradle: 프로메테우스 포맷으로 메트릭을 노출하는 micrometer-registry-prometheus 의존성을 추가했습니다.
- application.yml: management 설정을 통해 /actuator/prometheus 엔드포인트를 웹에 노출하고 활성화했습니다.

- SecurityConfig.java: 프로메테우스가 인증 없이 메트릭을 수집할 수 있도록 /actuator/** 경로를 시큐리티 화이트리스트에 추가했습니다.

코드 리팩토링 및 정리

- UserSyncEvent.java: Enum 타입의 데이터 저장 방식을 ORDINAL에서 STRING으로 변경하여 데이터 정합성과 가독성을 향상시켰습니다.
- application-test.yml: 불필요하게 주석 처리된 중복 설정을 제거했습니다.


# ⚙️ ISSUE
- closed #260 