### PR TITLE
fix(actuator): health 엔드포인트 노출하여 접근 오류 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,9 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus
+        include: prometheus,health
   endpoint:
     prometheus:
       enabled: true
+    health:
+      show-details: always


### PR DESCRIPTION
# 📄 Work Description
- 서버 헬스 체크를 위한 `/actuator/health` 엔드포인트가 웹에 노출되지 않아 접근이 불가능했던 문제를 해결했습니다. `application.yml` 파일의 `management.endpoints.web.exposure.include` 설정에 `health`를 추가하여 엔드포인트를 정상적으로 활성화했습니다.

---

# 💬 To Reviewers
- 이전 모니터링 환경 구축 PR(#262)에서 `health` 엔드포인트를 노출하는 설정이 누락되어 헬스 체크가 실패하는 문제가 있었습니다. 해당 설정을 추가하여 문제를 해결하는 간단한 수정입니다. 확인 부탁드립니다!