### PR TITLE
fix(cd): JAVA_OPTS 누락으로 인한 컨테이너 실행 실패 및 헬스 체크 오류 해결

### DIFF
--- a/.github/workflows/DOCKER-CD-STAGING.yml
+++ b/.github/workflows/DOCKER-CD-STAGING.yml
@@ -99,6 +99,7 @@ jobs:
             NEW_CONTAINER_NAME="${APP_NAME}-${NEW_PORT}"
             docker run -d --name ${NEW_CONTAINER_NAME} --restart always \
               -p ${NEW_PORT}:8080 \
+              -e JAVA_OPTS='-Xms256m -Xmx512m' \
               -e SPRING_PROFILES_ACTIVE=staging \
               -e SPRING_DATASOURCE_URL='${{ secrets.DB_URL }}' \
               -e SPRING_DATASOURCE_USERNAME='${{ secrets.DB_USERNAME }}' \
@@ -116,7 +117,7 @@ jobs:
               ${IMAGE_NAME}:latest
             
             echo "### 4. 헬스 체크를 시작합니다."
-            sleep 10
+            sleep 30
             for retry_count in {1..10}; do
                 echo "   > [${retry_count}/10] 서버 상태 체크 중..."
                 response=$(curl -s http://localhost:${NEW_PORT}/actuator/health)


### PR DESCRIPTION
# 📄 Work Description
## 문제점

GitHub Actions를 통한 자동 배포 시, 컨테이너는 실행되지만 내부 애플리케이션이 메모리 부족으로 즉시 종료되어 헬스 체크에 지속적으로 실패했습니다.

## 해결 방안

JAVA_OPTS 추가: 수동 실행 시에만 존재했던 Java 메모리 설정 (-e JAVA_OPTS='-Xms256m -Xmx512m')을 docker run 명령어에 추가하여, 컨테이너가 안정적으로 실행되도록 수정했습니다.

헬스 체크 대기 시간 증가: 애플리케이션이 완전히 구동될 시간을 확보하기 위해, 헬스 체크 전 대기 시간을 sleep 10에서 sleep 30으로 늘려 불필요한 실패를 방지했습니다.

스크립트 안정성 강화: set -e 옵션, 안정적인 포트 확인 로직 등 이전의 개선 사항을 모두 유지하여 배포 파이프라인의 안정성을 높였습니다.
