### PR TITLE
Feat : 커스텀 JWT Provider 구현

### DIFF
--- a/src/main/java/org/terning/terningserver/auth/dto/Token.java
+++ b/src/main/java/org/terning/terningserver/auth/dto/Token.java
@@ -1,0 +1,4 @@
+package org.terning.terningserver.auth.dto;
+
+public record Token(String accessToken, String refreshToken) {
+}

--- a/src/main/java/org/terning/terningserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/terning/terningserver/auth/jwt/JwtProvider.java
@@ -1,15 +1,23 @@
 package org.terning.terningserver.auth.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.terning.terningserver.auth.dto.Token;
-import org.terning.terningserver.common.config.ValueConfig;
 import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtException;
+import org.terning.terningserver.common.config.ValueConfig;
+
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
@@ -24,7 +32,7 @@ public class JwtProvider {
 
     @PostConstruct
     protected void init() {
-        secretKey = Keys.hmacShaKeyFor(valueConfig.getSecretKey().getBytes());
+        secretKey = Keys.hmacShaKeyFor(valueConfig.getSecretKey().getBytes(StandardCharsets.UTF_8));
     }
 
     public Token generateTokens(Long userId) {
@@ -47,14 +55,14 @@ public class JwtProvider {
         if (userIdClaim instanceof Number) {
             return ((Number) userIdClaim).longValue();
         }
-        throw new JwtException(JwtErrorCode.INVALID_USER_ID_TYPE.getMessage());
+        throw new JwtException(JwtErrorCode.INVALID_USER_ID_TYPE);
     }
 
     public String resolveToken(String rawToken) {
         if (rawToken != null && rawToken.startsWith(TOKEN_PREFIX)) {
             return rawToken.substring(TOKEN_PREFIX.length());
         }
-        throw new JwtException(JwtErrorCode.TOKEN_NOT_FOUND.getMessage());
+        throw new JwtException(JwtErrorCode.TOKEN_NOT_FOUND);
     }
 
     private String generateToken(Long userId, long expiration) {
@@ -77,9 +85,9 @@ public class JwtProvider {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            throw new JwtException(JwtErrorCode.EXPIRED_JWT_TOKEN.getMessage());
+            throw new JwtException(JwtErrorCode.EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException | MalformedJwtException | SecurityException | IllegalArgumentException e) {
-            throw new JwtException(JwtErrorCode.INVALID_JWT_TOKEN.getMessage());
+            throw new JwtException(JwtErrorCode.INVALID_JWT_TOKEN);
         }
     }
 }

--- a/src/main/java/org/terning/terningserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/terning/terningserver/auth/jwt/JwtProvider.java
@@ -1,0 +1,85 @@
+package org.terning.terningserver.auth.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.terning.terningserver.auth.dto.Token;
+import org.terning.terningserver.common.config.ValueConfig;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private static final String USER_ID_CLAIM = "userId";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private final ValueConfig valueConfig;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Keys.hmacShaKeyFor(valueConfig.getSecretKey().getBytes());
+    }
+
+    public Token generateTokens(Long userId) {
+        String accessToken = generateToken(userId, valueConfig.getAccessTokenExpired());
+        String refreshToken = generateToken(userId, valueConfig.getRefreshTokenExpired());
+        return new Token(accessToken, refreshToken);
+    }
+
+    public Token generateAccessToken(Long userId) {
+        String accessToken = generateToken(userId, valueConfig.getAccessTokenExpired());
+        return new Token(accessToken, null);
+    }
+
+    public Long getUserIdFrom(String authorizationHeader) {
+        String token = resolveToken(authorizationHeader);
+
+        Claims claims = parseClaims(token);
+
+        Object userIdClaim = claims.get(USER_ID_CLAIM);
+        if (userIdClaim instanceof Number) {
+            return ((Number) userIdClaim).longValue();
+        }
+        throw new JwtException(JwtErrorCode.INVALID_USER_ID_TYPE.getMessage());
+    }
+
+    public String resolveToken(String rawToken) {
+        if (rawToken != null && rawToken.startsWith(TOKEN_PREFIX)) {
+            return rawToken.substring(TOKEN_PREFIX.length());
+        }
+        throw new JwtException(JwtErrorCode.TOKEN_NOT_FOUND.getMessage());
+    }
+
+    private String generateToken(Long userId, long expiration) {
+        Claims claims = Jwts.claims();
+        claims.put(USER_ID_CLAIM, userId);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new JwtException(JwtErrorCode.EXPIRED_JWT_TOKEN.getMessage());
+        } catch (UnsupportedJwtException | MalformedJwtException | SecurityException | IllegalArgumentException e) {
+            throw new JwtException(JwtErrorCode.INVALID_JWT_TOKEN.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/terning/terningserver/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/org/terning/terningserver/auth/jwt/exception/JwtErrorCode.java
@@ -1,4 +1,4 @@
-package org.terning.terningserver.common.security.jwt.exception;
+package org.terning.terningserver.auth.jwt.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +11,8 @@ public enum JwtErrorCode {
     INVALID_USER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 userId 값입니다."),
     INVALID_USER_ID_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 userId 타입입니다."),
     INVALID_USER_DETAILS_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 UserDetail 타입입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Authorization 헤더에 토큰이 없습니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     ;
 
     public static final String PREFIX = "[JWT ERROR]";

--- a/src/main/java/org/terning/terningserver/auth/jwt/exception/JwtException.java
+++ b/src/main/java/org/terning/terningserver/auth/jwt/exception/JwtException.java
@@ -1,4 +1,4 @@
-package org.terning.terningserver.common.security.jwt.exception;
+package org.terning.terningserver.auth.jwt.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/org/terning/terningserver/common/config/ValueConfig.java
+++ b/src/main/java/org/terning/terningserver/common/config/ValueConfig.java
@@ -1,12 +1,8 @@
 package org.terning.terningserver.common.config;
 
-import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 @Configuration
 @Getter
@@ -26,9 +22,4 @@ public class ValueConfig {
 
     @Value("${jwt.refresh-token-expired}")
     private Long refreshTokenExpired;
-
-    @PostConstruct
-    protected void init() {
-        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes(StandardCharsets.UTF_8));
-    }
 }

--- a/src/main/java/org/terning/terningserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/terning/terningserver/common/exception/GlobalExceptionHandler.java
@@ -13,8 +13,8 @@ import org.terning.terningserver.auth.common.exception.AuthErrorCode;
 import org.terning.terningserver.auth.common.exception.AuthException;
 import org.terning.terningserver.common.exception.dto.ErrorResponse;
 import org.terning.terningserver.common.exception.enums.ErrorMessage;
-import org.terning.terningserver.common.security.jwt.exception.JwtErrorCode;
-import org.terning.terningserver.common.security.jwt.exception.JwtException;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtException;
 
 @RestControllerAdvice
 @Slf4j

--- a/src/main/java/org/terning/terningserver/common/security/jwt/application/JwtClaimsGenerator.java
+++ b/src/main/java/org/terning/terningserver/common/security/jwt/application/JwtClaimsGenerator.java
@@ -6,7 +6,7 @@ import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-import org.terning.terningserver.common.security.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
 
 import java.util.Map;
 

--- a/src/main/java/org/terning/terningserver/common/security/jwt/application/JwtUserIdExtractor.java
+++ b/src/main/java/org/terning/terningserver/common/security/jwt/application/JwtUserIdExtractor.java
@@ -3,8 +3,8 @@ package org.terning.terningserver.common.security.jwt.application;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.terning.terningserver.common.security.jwt.exception.JwtErrorCode;
-import org.terning.terningserver.common.security.jwt.exception.JwtException;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtException;
 import org.terning.terningserver.common.security.jwt.auth.JwtClaimsParser;
 
 @Component

--- a/src/main/java/org/terning/terningserver/common/security/jwt/auth/JwtClaimsParser.java
+++ b/src/main/java/org/terning/terningserver/common/security/jwt/auth/JwtClaimsParser.java
@@ -5,8 +5,8 @@ import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.terning.terningserver.common.config.ValueConfig;
-import org.terning.terningserver.common.security.jwt.exception.JwtErrorCode;
-import org.terning.terningserver.common.security.jwt.exception.JwtException;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtException;
 import org.terning.terningserver.common.security.jwt.provider.JwtKeyProvider;
 
 @Service

--- a/src/main/java/org/terning/terningserver/common/security/jwt/auth/UserIdConverter.java
+++ b/src/main/java/org/terning/terningserver/common/security/jwt/auth/UserIdConverter.java
@@ -1,7 +1,7 @@
 package org.terning.terningserver.common.security.jwt.auth;
 
-import org.terning.terningserver.common.security.jwt.exception.JwtErrorCode;
-import org.terning.terningserver.common.security.jwt.exception.JwtException;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtException;
 
 public class UserIdConverter {
 

--- a/src/main/java/org/terning/terningserver/common/security/jwt/filter/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/terning/terningserver/common/security/jwt/filter/CustomJwtAuthenticationEntryPoint.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.terning.terningserver.common.security.jwt.exception.JwtErrorCode;
-import org.terning.terningserver.common.security.jwt.exception.JwtException;
+import org.terning.terningserver.auth.jwt.exception.JwtErrorCode;
+import org.terning.terningserver.auth.jwt.exception.JwtException;
 
 import java.io.IOException;
 

--- a/src/main/java/org/terning/terningserver/external/pushNotification/user/domain/UserSyncEvent.java
+++ b/src/main/java/org/terning/terningserver/external/pushNotification/user/domain/UserSyncEvent.java
@@ -1,6 +1,7 @@
 package org.terning.terningserver.external.pushNotification.user.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,7 +25,7 @@ public class UserSyncEvent {
 
     private Long userId;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private UserSyncEventType eventType;
 
     private String newValue;


### PR DESCRIPTION
# 📄 Work Description

이번 PR은 Spring Security 의존성을 점진적으로 제거하기 위한 첫 단계로, 기존에 여러 곳에 분산되어 있던 JWT 관련 로직을 auth 도메인 내의 커스텀 JwtProvider로 통합하고 리팩토링하는 작업을 진행했습니다. 이를 통해 인증/인가 코드의 응집도를 높이고 향후 유지보수성을 개선하고자 합니다.
-   `auth` 도메인에 특화된 커스텀 `JwtProvider`를 구현하여 JWT 생성, 검증 및 사용자 ID 추출 로직을 통합했습니다.
  - Access Token과 Refresh Token을 함께 반환하기 위한 `Token` DTO를 `record` 형식으로 추가했습니다.
  - JWT 관련 예외 처리 클래스(`JwtException`, `JwtErrorCode`)의 패키지 위치를 `common.security`에서 `auth.jwt`로 이동하여 응집도를 높였습니다.
  - `JwtProvider` 변경에 따라, 영향을 받는 다른 클래스들의 의존성 및 import 경로를 수정했습니다.

# ⚙️ ISSUE
- closed #278 



