### PR TITLE
[♻️ refactor/#297] 신규 유저 로그인 시 응답 데이터 누락 문제 해결

### DIFF
--- a/src/main/java/org/terning/terningserver/auth/dto/response/SignInResponse.java
+++ b/src/main/java/org/terning/terningserver/auth/dto/response/SignInResponse.java
@@ -1,10 +1,8 @@
 package org.terning.terningserver.auth.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.terning.terningserver.auth.dto.Token;
 import org.terning.terningserver.user.domain.AuthType;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SignInResponse(
         String accessToken,
         String refreshToken,


### PR DESCRIPTION
# 📄 Work Description
- 신규 유저가 소셜 로그인을 시도할 때, 클라이언트 측에서 발생하는 응답 데이터 파싱 오류를 해결했습니다.
- **문제 원인**: `SignInResponse` DTO에 적용된 `@JsonInclude(JsonInclude.Include.NON_NULL)` 어노테이션으로 인해, `null` 값을 가진 필드(`accessToken`, `refreshToken` 등)가 JSON 응답에서 제외되었습니다.
- **해결**: 해당 어노테이션을 제거하여, `null` 값을 가진 필드도 항상 응답에 포함되도록 수정했습니다.

# 💬 To Reviewers
- 신규 유저의 소셜 로그인 케이스를 테스트할 때, 응답 JSON 바디에 `accessToken`, `refreshToken`, `userId` 필드가 `null` 값으로 정상적으로 포함되는지 확인 부탁드립니다.
- 이번 수정은 신규 유저의 응답 구조만 변경하며, 기존 유저의 로그인 응답에는 영향을 주지 않습니다.

# ⚙️ ISSUE
- closed #297